### PR TITLE
Avoid default priority queue which can be concurrent causing out of order messages delivered to delegate

### DIFF
--- a/Websocket.swift
+++ b/Websocket.swift
@@ -9,7 +9,7 @@
 import Foundation
 import CoreFoundation
 
-public protocol WebsocketDelegate {
+public protocol WebsocketDelegate: class {
     func websocketDidConnect()
     func websocketDidDisconnect(error: NSError?)
     func websocketDidWriteError(error: NSError?)
@@ -71,7 +71,7 @@ public class Websocket : NSObject, NSStreamDelegate {
         var buffer: NSMutableData?
     }
     
-    public var delegate: WebsocketDelegate?
+    public weak var delegate: WebsocketDelegate?
     private var url: NSURL
     private var inputStream: NSInputStream?
     private var outputStream: NSOutputStream?
@@ -519,13 +519,13 @@ public class Websocket : NSObject, NSStreamDelegate {
                     writeError(CloseCode.Encoding.toRaw())
                     return false
                 }
-                dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0),{
+                dispatch_async(dispatch_get_main_queue(),{
                     self.workaroundMethod()
                     self.delegate?.websocketDidReceiveMessage(str!)
                 })
             } else if response.code == .BinaryFrame {
                 let data = response.buffer! //local copy so it is perverse for writing
-                dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0),{
+                dispatch_async(dispatch_get_main_queue(),{
                     self.workaroundMethod()
                     self.delegate?.websocketDidReceiveData(data)
                 })


### PR DESCRIPTION
Came across this using starscream in a library we are preparing to open source.  It was causing painful issues as order really mattered for our callbacks.  We could make our own background queue and ensure concurrency level 1 instead of this fix martialing back to the main thread, however I would assume most users will martial back onto the main thread themselves anyway for the majority of cases so might be better to perform this fix and then they can choose to pass the work onto the background if they truly want to do background processing before acting on the data.
- Fixing concurrent race that occurs when calling delegate with
  websocketDidReceiveMessage and websocketDidReceiveData with a default
  priority queue which so happens to have higher 1 concurrency level.
  Also this ensures delegate is always fired on the main queue making
  the library easier to use.
- Declare delegate as weak to avoid strongly holding onto the delegate.
