### PR TITLE
fixed crash when inputStream and outputStream need to be closed

### DIFF
--- a/WebSocket.swift
+++ b/WebSocket.swift
@@ -268,11 +268,14 @@ public class WebSocket : NSObject, NSStreamDelegate {
         if writeQueue != nil {
             writeQueue!.waitUntilAllOperationsAreFinished()
         }
-        inputStream!.removeFromRunLoop(NSRunLoop.currentRunLoop(), forMode: NSDefaultRunLoopMode)
-        outputStream!.removeFromRunLoop(NSRunLoop.currentRunLoop(), forMode: NSDefaultRunLoopMode)
-        inputStream!.close()
-        outputStream!.close()
-        inputStream = nil
+        if inputStream != nil {
+            inputStream!.removeFromRunLoop(NSRunLoop.currentRunLoop(), forMode: NSDefaultRunLoopMode)
+            inputStream!.close()
+        }
+        if outputStream != nil {
+            outputStream!.removeFromRunLoop(NSRunLoop.currentRunLoop(), forMode: NSDefaultRunLoopMode)
+            outputStream!.close()
+        }        
         outputStream = nil
         isRunLoop = false
         connected = false


### PR DESCRIPTION
When you're in Airplane mode inputStream and outputStream can be nil and trying to force unwrapping them and then close them throws an exception and crashes the app. I wrapped them with an if block where I check if they're not nil first.