### PR TITLE
Fix .gitignore so that it ignores Carthage build directory as well

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 
 # Xcode
 .DS_Store
-build/
+build
 *.pbxuser
 !default.pbxuser
 *.mode1v3


### PR DESCRIPTION
This patch fixes a subtle issue with Carthage when Starscream is added as a submodule. Carthage creates a build directory, which makes submodule appear as dirty.