### PR TITLE
Pong received delegate

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ func websocketDidReceiveData(socket: WebSocket, data: NSData) {
 }
 ```
 
-### Optional: websocketDidReceivePong (required protocol: WebSocketPongDelegate)
+### Optional: websocketDidReceivePong *(required protocol: WebSocketPongDelegate)*
 
 websocketDidReceivePong is called when the client gets a pong response from the connection. You need to implement the WebSocketPongDelegate protocol and set an additional delegate, eg: ` socket.pongDelegate = self`
 
@@ -81,7 +81,7 @@ func websocketDidReceivePong(socket: WebSocket) {
 }
 ```
 
-### The delegate methods give you a simple way to handle data from the server, but how do you send data?
+## The delegate methods give you a simple way to handle data from the server, but how do you send data?
 
 ### writeData
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,17 @@ func websocketDidReceiveData(socket: WebSocket, data: NSData) {
 }
 ```
 
-The delegate methods give you a simple way to handle data from the server, but how do you send data?
+### Optional: websocketDidReceivePong (required protocol: WebSocketPongDelegate)
+
+websocketDidReceivePong is called when the client gets a pong response from the connection. You need to implement the WebSocketPongDelegate protocol and set an additional delegate, eg: ` socket.pongDelegate = self`
+
+```swift
+func websocketDidReceivePong(socket: WebSocket) {
+	println("Got pong!")
+}
+```
+
+### The delegate methods give you a simple way to handle data from the server, but how do you send data?
 
 ### writeData
 

--- a/WebSocket.swift
+++ b/WebSocket.swift
@@ -16,6 +16,10 @@ public protocol WebSocketDelegate: class {
     func websocketDidReceiveData(socket: WebSocket, data: NSData)
 }
 
+public protocol WebSocketPongDelegate: class {
+    func websocketDidReceivePong(socket: WebSocket)
+}
+
 public class WebSocket : NSObject, NSStreamDelegate {
     
     enum OpCode : UInt8 {
@@ -80,6 +84,7 @@ public class WebSocket : NSObject, NSStreamDelegate {
     }
     
     public weak var delegate: WebSocketDelegate?
+    public weak var pongDelegate: WebSocketPongDelegate?
     private var url: NSURL
     private var inputStream: NSInputStream?
     private var outputStream: NSOutputStream?
@@ -503,6 +508,7 @@ public class WebSocket : NSObject, NSStreamDelegate {
                 data = NSData(bytes: UnsafePointer<UInt8>((buffer+offset)), length: Int(len))
             }
             if receivedOpcode == OpCode.Pong.rawValue {
+                self.pongDelegate?.websocketDidReceivePong(self)
                 let step = Int(offset+numericCast(len))
                 let extra = bufferLen-step
                 if extra > 0 {


### PR DESCRIPTION
I implemented a websocketDidReceivePongDelegate in a separate protocol.
This way it will be optional and will not break existing code where users would otherwise have to implement this method.

I am aware that it's possible to use `@objc` and `optional` but it comes with caveats. 
According to Ash Furrow it seems that separate protocols is the better solution: http://ashfurrow.com/blog/protocols-and-swift/

I'm only a few days into learning Swift so bear with me :)