### PR TITLE
expose disconnectStream to public for some cases we need to close and

### DIFF
--- a/WebSocket.swift
+++ b/WebSocket.swift
@@ -276,7 +276,7 @@ public class WebSocket : NSObject, NSStreamDelegate {
         }
     }
     //disconnect the stream object
-    private func disconnectStream(error: NSError?) {
+    public func disconnectStream(error: NSError?) {
         if writeQueue != nil {
             writeQueue!.waitUntilAllOperationsAreFinished()
         }


### PR DESCRIPTION
cleanup the underlay stream when webscoket haven’t connected to remote server