### PR TITLE
When using cert pinning with public keys, only require one match.

### DIFF
--- a/SSLSecurity.swift
+++ b/SSLSecurity.swift
@@ -128,18 +128,13 @@ public class SSLSecurity {
         SecTrustSetPolicies(trust,policy)
         if self.usePublicKeys {
             if let keys = self.pubKeys {
-                var trustedCount = 0
                 let serverPubKeys = publicKeyChainForTrust(trust)
                 for serverKey in serverPubKeys as [AnyObject] {
                     for key in keys as [AnyObject] {
                         if serverKey.isEqual(key) {
-                            trustedCount++
-                            break
+                            return true
                         }
                     }
-                }
-                if trustedCount == serverPubKeys.count {
-                    return true
                 }
             }
         } else if let certs = self.certificates {


### PR DESCRIPTION
Typically in my experience when using public key pinning instead of cert pinning the reason for doing so is that you can avoid pinning the entire certificate chain and instead only pin the actual certificate, thus allowing you to change the rest of the certificate chain in the future with e.g. a renewal via a different cert authority.

This change requires one of the server certificate public keys to match the local stored public key, instead of requiring that all cert public keys in the chain be matched with locally stored public keys. 

If you prefer, I'd be happy to implement a PR that either requires explicitly that the server cert's public key be matched (this version could match intermediate if somebody stores that for some reason) or that implements this behavior in addition to preserving the previous behavior.