### PR TITLE
Make CloseCode enum public

### DIFF
--- a/WebSocket.swift
+++ b/WebSocket.swift
@@ -60,6 +60,8 @@ public class WebSocket : NSObject, NSStreamDelegate {
         case MessageTooBig          = 1009
     }
 
+    public static let ErrorDomain = "WebSocket"
+
     enum InternalErrorCode : UInt16 {
         // 0-999 WebSocket status codes not used
         case OutputStreamWriteError  = 1
@@ -665,7 +667,7 @@ public class WebSocket : NSObject, NSStreamDelegate {
     private func errorWithDetail(detail: String, code: UInt16) -> NSError {
         var details = Dictionary<String,String>()
         details[NSLocalizedDescriptionKey] =  detail
-        return NSError(domain: "Websocket", code: Int(code), userInfo: details)
+        return NSError(domain: WebSocket.ErrorDomain, code: Int(code), userInfo: details)
     }
     
     ///write a an error to the socket

--- a/WebSocket.swift
+++ b/WebSocket.swift
@@ -47,7 +47,7 @@ public class WebSocket : NSObject, NSStreamDelegate {
         //B-F reserved.
     }
     
-    enum CloseCode : UInt16 {
+    public enum CloseCode : UInt16 {
         case Normal                 = 1000
         case GoingAway              = 1001
         case ProtocolError          = 1002


### PR DESCRIPTION
Since they get passed to the websocketDidDisconnect delegate method,
making them public means that the codes can be switched against without
needing magic numbers.