### PR TITLE
Unwrap header safely when validating response.

### DIFF
--- a/WebSocket.swift
+++ b/WebSocket.swift
@@ -433,9 +433,10 @@ public class WebSocket : NSObject, NSStreamDelegate {
         }
         if let cfHeaders = CFHTTPMessageCopyAllHeaderFields(response) {
             let headers = cfHeaders.takeRetainedValue() as NSDictionary
-            let acceptKey = headers[headerWSAcceptName] as! NSString
-            if acceptKey.length > 0 {
-                return true
+            if let acceptKey = headers[headerWSAcceptName] as? NSString {
+                if acceptKey.length > 0 {
+                    return true
+                }
             }
         }
         return false


### PR DESCRIPTION
When the `Sec-WebSocket-Accept` header is missing in the response, the app crashes due to an unwrapped nil value. With this pull request, the header is safely unwrapped and the app will not crash but simply disconnect.

The header can be missing when some proxy between the client and server eats this header (for whatever reason).