### PR TITLE
Close stream after error

### DIFF
--- a/Source/WebSocket.swift
+++ b/Source/WebSocket.swift
@@ -700,6 +700,9 @@ public class WebSocket : NSObject, NSStreamDelegate {
         let buffer = UnsafeMutablePointer<UInt8>(buf!.bytes)
         WebSocket.writeUint16(buffer, offset: 0, value: code)
         dequeueWrite(NSData(bytes: buffer, length: sizeof(UInt16)), code: .ConnectionClose)
+        
+        inputStream?.close()
+        outputStream?.close()
     }
     ///used to write things to the stream
     private func dequeueWrite(data: NSData, code: OpCode) {


### PR DESCRIPTION
We are suffering a crash when server close the connect but several data still coming in. The crash stack indicates it might be related to the `com.vluxe.starscream.websocket` queue, which is used to handle streaming data. I posted the crashed stack below for a reference:

```
Thread 9 name:  Dispatch queue: com.vluxe.starscream.websocket 
<Error>: 	Thread 9 Crashed: 
<Error>: 	0   libobjc.A.dylib                0x0000000193a13bd0 0x1939f8000 + 113616 
<Error>: 	1   CoreFoundation                 0x0000000181d37f48 0x181c64000 + 868168 
<Error>: 	2   CoreFoundation                 0x0000000181ce3d0c 0x181c64000 + 523532 
<Error>: 	3   CoreFoundation                 0x0000000181d4fd78 0x181c64000 + 966008 
<Error>: 	4   libdispatch.dylib              0x000000019407d990 0x19407c000 + 6544 
<Error>: 	5   libdispatch.dylib              0x000000019407d950 0x19407c000 + 6480 
<Error>: 	6   libdispatch.dylib              0x00000001940880a0 0x19407c000 + 49312 
<Error>: 	7   libdispatch.dylib              0x0000000194080a58 0x19407c000 + 19032 
<Error>: 	8   libdispatch.dylib              0x000000019408a314 0x19407c000 + 58132 
<Error>: 	9   libdispatch.dylib              0x000000019408bc48 0x19407c000 + 64584 
<Error>: 	10  libsystem_pthread.dylib        0x000000019425d218 0x19425c000 + 4632 
<Error>: 	11  libsystem_pthread.dylib        0x000000019425cedc 0x19425c000 + 3804 
```

I tried to fix it by closing the streaming after getting an error and it seems work fine for us. However, I am not an expert on web socket so I am not sure whether something else breaks or not.

Would you mind to have a look at it? Thanks.