### PR TITLE
Fix crashing when reconnecting repeatedly

### DIFF
--- a/Source/WebSocket.swift
+++ b/Source/WebSocket.swift
@@ -167,8 +167,8 @@ public class WebSocket : NSObject, NSStreamDelegate {
     public func disconnect(forceTimeout forceTimeout: NSTimeInterval? = nil) {
         switch forceTimeout {
             case .Some(let seconds) where seconds > 0:
-                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(seconds * Double(NSEC_PER_SEC))), queue) { [unowned self] in
-                    self.disconnectStream(nil)
+                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(seconds * Double(NSEC_PER_SEC))), queue) { [weak self] in
+                    self?.disconnectStream(nil)
                     }
                 fallthrough
             case .None:
@@ -308,13 +308,13 @@ public class WebSocket : NSObject, NSStreamDelegate {
         
         let bytes = UnsafePointer<UInt8>(data.bytes)
         var timeout = 5000000 //wait 5 seconds before giving up
-        writeQueue.addOperationWithBlock { [unowned self] in
+        writeQueue.addOperationWithBlock { [weak self] in
             while !outStream.hasSpaceAvailable {
                 usleep(100) //wait until the socket is ready
                 timeout -= 100
                 if timeout < 0 {
-                    self.cleanupStream()
-                    self.doDisconnect(self.errorWithDetail("write wait timed out", code: 2))
+                    self?.cleanupStream()
+                    self?.doDisconnect(self?.errorWithDetail("write wait timed out", code: 2))
                     return
                 } else if outStream.streamError != nil {
                     return //disconnectStream will be called.


### PR DESCRIPTION
I am not quite sure why you are using `unowned` here. But this commit fixed some crash for me, when I try to reconnect to the web socket repeatedly while the network is bad.

I dealloc and reinit a web socket object every time the reconnecting button is clicked. And you may reproduce the crash easily if you turn off the network, and try to reconnect while you turn the network on.