### PR TITLE
process buffered messages non-recursively

### DIFF
--- a/Source/WebSocket.swift
+++ b/Source/WebSocket.swift
@@ -408,7 +408,7 @@ public class WebSocket : NSObject, NSStreamDelegate {
         if !connected {
             processTCPHandshake(buffer, bufferLen: length)
         } else {
-            processRawMessage(buffer, bufferLen: length)
+            processRawMessagesInBuffer(buffer, bufferLen: length)
         }
         inputQueue = inputQueue.filter{$0 != data}
         dequeueInput()
@@ -457,7 +457,7 @@ public class WebSocket : NSObject, NSStreamDelegate {
             totalSize += 1 //skip the last \n
             let restSize = bufferLen - totalSize
             if restSize > 0 {
-                processRawMessage((buffer+totalSize),bufferLen: restSize)
+                processRawMessagesInBuffer(buffer + totalSize, bufferLen: restSize)
             }
             return 0 //success
         }
@@ -509,13 +509,16 @@ public class WebSocket : NSObject, NSStreamDelegate {
             buffer[offset + i] = UInt8((value >> (8*UInt64(7 - i))) & 0xff)
         }
     }
-    
-    ///process the websocket data
-    private func processRawMessage(buffer: UnsafePointer<UInt8>, bufferLen: Int) {
+
+    /// Process one message at the start of `buffer`. Return another buffer (sharing storage) that contains the leftover contents of `buffer` that I didn't process.
+    @warn_unused_result
+    private func processOneRawMessage(inBuffer buffer: UnsafeBufferPointer<UInt8>) -> UnsafeBufferPointer<UInt8> {
         let response = readStack.last
+        let baseAddress = buffer.baseAddress
+        let bufferLen = buffer.count
         if response != nil && bufferLen < 2  {
-            fragBuffer = NSData(bytes: buffer, length: bufferLen)
-            return
+            fragBuffer = NSData(buffer: buffer)
+            return emptyBuffer
         }
         if let response = response where response.bytesLeft > 0 {
             var len = response.bytesLeft
@@ -525,24 +528,20 @@ public class WebSocket : NSObject, NSStreamDelegate {
                 extra = 0
             }
             response.bytesLeft -= len
-            response.buffer?.appendData(NSData(bytes: buffer, length: len))
+            response.buffer?.appendData(NSData(bytes: baseAddress, length: len))
             processResponse(response)
-            let offset = bufferLen - extra
-            if extra > 0 {
-                processExtra((buffer+offset), bufferLen: extra)
-            }
-            return
+            return buffer.fromOffset(bufferLen - extra)
         } else {
-            let isFin = (FinMask & buffer[0])
-            let receivedOpcode = OpCode(rawValue: (OpCodeMask & buffer[0]))
-            let isMasked = (MaskMask & buffer[1])
-            let payloadLen = (PayloadLenMask & buffer[1])
+            let isFin = (FinMask & baseAddress[0])
+            let receivedOpcode = OpCode(rawValue: (OpCodeMask & baseAddress[0]))
+            let isMasked = (MaskMask & baseAddress[1])
+            let payloadLen = (PayloadLenMask & baseAddress[1])
             var offset = 2
-            if (isMasked > 0 || (RSVMask & buffer[0]) > 0) && receivedOpcode != .Pong {
+            if (isMasked > 0 || (RSVMask & baseAddress[0]) > 0) && receivedOpcode != .Pong {
                 let errCode = CloseCode.ProtocolError.rawValue
                 doDisconnect(errorWithDetail("masked and rsv data is not currently supported", code: errCode))
                 writeError(errCode)
-                return
+                return emptyBuffer
             }
             let isControlFrame = (receivedOpcode == .ConnectionClose || receivedOpcode == .Ping)
             if !isControlFrame && (receivedOpcode != .BinaryFrame && receivedOpcode != .ContinueFrame &&
@@ -550,20 +549,20 @@ public class WebSocket : NSObject, NSStreamDelegate {
                     let errCode = CloseCode.ProtocolError.rawValue
                     doDisconnect(errorWithDetail("unknown opcode: \(receivedOpcode)", code: errCode))
                     writeError(errCode)
-                    return
+                    return emptyBuffer
             }
             if isControlFrame && isFin == 0 {
                 let errCode = CloseCode.ProtocolError.rawValue
                 doDisconnect(errorWithDetail("control frames can't be fragmented", code: errCode))
                 writeError(errCode)
-                return
+                return emptyBuffer
             }
             if receivedOpcode == .ConnectionClose {
                 var code = CloseCode.Normal.rawValue
                 if payloadLen == 1 {
                     code = CloseCode.ProtocolError.rawValue
                 } else if payloadLen > 1 {
-                    code = WebSocket.readUint16(buffer, offset: offset)
+                    code = WebSocket.readUint16(baseAddress, offset: offset)
                     if code < 1000 || (code > 1003 && code < 1007) || (code > 1011 && code < 3000) {
                         code = CloseCode.ProtocolError.rawValue
                     }
@@ -572,7 +571,7 @@ public class WebSocket : NSObject, NSStreamDelegate {
                 if payloadLen > 2 {
                     let len = Int(payloadLen-2)
                     if len > 0 {
-                        let bytes = UnsafePointer<UInt8>((buffer+offset))
+                        let bytes = baseAddress + offset
                         let str: NSString? = NSString(data: NSData(bytes: bytes, length: len), encoding: NSUTF8StringEncoding)
                         if str == nil {
                             code = CloseCode.ProtocolError.rawValue
@@ -581,23 +580,23 @@ public class WebSocket : NSObject, NSStreamDelegate {
                 }
                 doDisconnect(errorWithDetail("connection closed by server", code: code))
                 writeError(code)
-                return
+                return emptyBuffer
             }
             if isControlFrame && payloadLen > 125 {
                 writeError(CloseCode.ProtocolError.rawValue)
-                return
+                return emptyBuffer
             }
             var dataLength = UInt64(payloadLen)
             if dataLength == 127 {
-                dataLength = WebSocket.readUint64(buffer, offset: offset)
+                dataLength = WebSocket.readUint64(baseAddress, offset: offset)
                 offset += sizeof(UInt64)
             } else if dataLength == 126 {
-                dataLength = UInt64(WebSocket.readUint16(buffer, offset: offset))
+                dataLength = UInt64(WebSocket.readUint16(baseAddress, offset: offset))
                 offset += sizeof(UInt16)
             }
             if bufferLen < offset || UInt64(bufferLen - offset) < dataLength {
-                fragBuffer = NSData(bytes: buffer, length: bufferLen)
-                return
+                fragBuffer = NSData(bytes: baseAddress, length: bufferLen)
+                return emptyBuffer
             }
             var len = dataLength
             if dataLength > UInt64(bufferLen) {
@@ -608,7 +607,7 @@ public class WebSocket : NSObject, NSStreamDelegate {
                 len = 0
                 data = NSData()
             } else {
-                data = NSData(bytes: UnsafePointer<UInt8>((buffer+offset)), length: Int(len))
+                data = NSData(bytes: baseAddress+offset, length: Int(len))
             }
             if receivedOpcode == .Pong {
                 if canDispatch {
@@ -618,12 +617,7 @@ public class WebSocket : NSObject, NSStreamDelegate {
                         s.pongDelegate?.websocketDidReceivePong(s)
                     }
                 }
-                let step = Int(offset+numericCast(len))
-                let extra = bufferLen-step
-                if extra > 0 {
-                    processRawMessage((buffer+step), bufferLen: extra)
-                }
-                return
+                return buffer.fromOffset(offset + Int(len))
             }
             var response = readStack.last
             if isControlFrame {
@@ -633,7 +627,7 @@ public class WebSocket : NSObject, NSStreamDelegate {
                 let errCode = CloseCode.ProtocolError.rawValue
                 doDisconnect(errorWithDetail("continue frame before a binary or text frame", code: errCode))
                 writeError(errCode)
-                return
+                return emptyBuffer
             }
             var isNew = false
             if response == nil {
@@ -642,7 +636,7 @@ public class WebSocket : NSObject, NSStreamDelegate {
                     doDisconnect(errorWithDetail("first frame can't be a continue frame",
                         code: errCode))
                     writeError(errCode)
-                    return
+                    return emptyBuffer
                 }
                 isNew = true
                 response = WSResponse()
@@ -657,7 +651,7 @@ public class WebSocket : NSObject, NSStreamDelegate {
                     doDisconnect(errorWithDetail("second and beyond of fragment message must be a continue frame",
                         code: errCode))
                     writeError(errCode)
-                    return
+                    return emptyBuffer
                 }
                 response!.buffer!.appendData(data)
             }
@@ -672,23 +666,21 @@ public class WebSocket : NSObject, NSStreamDelegate {
             }
             
             let step = Int(offset+numericCast(len))
-            let extra = bufferLen-step
-            if extra > 0 {
-                processExtra((buffer+step), bufferLen: extra)
-            }
-        }
-        
-    }
-    
-    ///process the extra of a buffer
-    private func processExtra(buffer: UnsafePointer<UInt8>, bufferLen: Int) {
-        if bufferLen < 2 {
-            fragBuffer = NSData(bytes: buffer, length: bufferLen)
-        } else {
-            processRawMessage(buffer, bufferLen: bufferLen)
+            return buffer.fromOffset(step)
         }
     }
-    
+
+    /// Process all messages in the buffer if possible.
+    private func processRawMessagesInBuffer(pointer: UnsafePointer<UInt8>, bufferLen: Int) {
+        var buffer = UnsafeBufferPointer(start: pointer, count: bufferLen)
+        repeat {
+            buffer = processOneRawMessage(inBuffer: buffer)
+        } while buffer.count >= 2
+        if buffer.count > 0 {
+            fragBuffer = NSData(buffer: buffer)
+        }
+    }
+
     ///process the finished response of a buffer
     private func processResponse(response: WSResponse) -> Bool {
         if response.isFin && response.bytesLeft <= 0 {
@@ -816,3 +808,22 @@ public class WebSocket : NSObject, NSStreamDelegate {
     }
     
 }
+
+private extension NSData {
+
+    convenience init(buffer: UnsafeBufferPointer<UInt8>) {
+        self.init(bytes: buffer.baseAddress, length: buffer.count)
+    }
+
+}
+
+private extension UnsafeBufferPointer {
+
+    func fromOffset(offset: Int) -> UnsafeBufferPointer<Element> {
+        return UnsafeBufferPointer<Element>(start: baseAddress.advancedBy(offset), count: count - offset)
+    }
+
+}
+
+private let emptyBuffer = UnsafeBufferPointer<UInt8>(start: nil, count: 0)
+


### PR DESCRIPTION
I had a Starscream crash because Starscream read a full buffer (BUFFER_MAX = 4096 bytes), and the buffer was full of 17 byte messages (meaning, 240 full messages plus most of the next message). The mutual recursion between `processRawMessage` and `processExtra` caused a stack overflow. (The default stack size for a background queue is 512 KB and, at least in a Debug build, the `processRawMessage` method uses a lot of stack space.)

This patch changes the buffer handling to be non-recursive.

The old `processRawMessage` method is now `processOneRawMessage`.  It returns the “extra” contents of the buffer instead of calling `processExtra` recursively.

The old `processExtra` method is now the `processRawMessagesInBuffer` method. It contains a loop that calls `processOneRawMessage` repeatedly until there's no more data in the buffer.

All calls to the old `processRawMessage` method (outside of `processRawMessagesInBuffer`) now call `processRawMessagesInBuffer`.
