### PR TITLE
Posting NSNotification about websocket connection and disconnection

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ socket.onData = { (data: NSData) in
 socket.connect()
 ```
 
+One more: you can listen to socket connection and disconnection via notifications. Starscream posts `WebsocketDidConnectNotification` and `WebsocketDidDisconnectNotification`. You can find an `NSError` that caused the disconection by accessing `WebsocketDisconnectionErrorKeyName` on notification `userInfo`.
+
 
 ## The delegate methods give you a simple way to handle data from the server, but how do you send data?
 

--- a/Source/WebSocket.swift
+++ b/Source/WebSocket.swift
@@ -23,6 +23,9 @@ import Foundation
 import CoreFoundation
 import Security
 
+public let WebsocketDidConnectNotification = "WebsocketDidConnectNotification"
+public let WebsocketDidDisconnectNotification = "WebsocketDidDisconnectNotification"
+
 public protocol WebSocketDelegate: class {
     func websocketDidConnect(socket: WebSocket)
     func websocketDidDisconnect(socket: WebSocket, error: NSError?)
@@ -130,6 +133,7 @@ public class WebSocket : NSObject, NSStreamDelegate {
     private var didDisconnect = false
     private var readyToWrite = false
     private let mutex = NSLock()
+    private let notificationCenter = NSNotificationCenter.defaultCenter()
     private var canDispatch: Bool {
         mutex.lock()
         let canWork = readyToWrite
@@ -439,6 +443,7 @@ public class WebSocket : NSObject, NSStreamDelegate {
                 guard let s = self else { return }
                 s.onConnect?()
                 s.delegate?.websocketDidConnect(s)
+                s.notificationCenter.postNotificationName(WebsocketDidConnectNotification, object: self)
             }
         case -1:
             fragBuffer = NSData(bytes: buffer, length: bufferLen)
@@ -817,6 +822,7 @@ public class WebSocket : NSObject, NSStreamDelegate {
             guard let s = self else { return }
             s.onDisconnect?(error)
             s.delegate?.websocketDidDisconnect(s, error: error)
+            s.notificationCenter.postNotificationName(WebsocketDidDisconnectNotification, object: self)
         }
     }
     

--- a/Source/WebSocket.swift
+++ b/Source/WebSocket.swift
@@ -25,6 +25,7 @@ import Security
 
 public let WebsocketDidConnectNotification = "WebsocketDidConnectNotification"
 public let WebsocketDidDisconnectNotification = "WebsocketDidDisconnectNotification"
+public let WebsocketDisconnectionErrorKeyName = "WebsocketDisconnectionErrorKeyName"
 
 public protocol WebSocketDelegate: class {
     func websocketDidConnect(socket: WebSocket)
@@ -822,7 +823,8 @@ public class WebSocket : NSObject, NSStreamDelegate {
             guard let s = self else { return }
             s.onDisconnect?(error)
             s.delegate?.websocketDidDisconnect(s, error: error)
-            s.notificationCenter.postNotificationName(WebsocketDidDisconnectNotification, object: self)
+            let userInfo = error.map({ [WebsocketDisconnectionErrorKeyName: $0] })
+            s.notificationCenter.postNotificationName(WebsocketDidDisconnectNotification, object: self, userInfo: userInfo)
         }
     }
     


### PR DESCRIPTION
In this PR, `WebSocket` posts `WebsocketDidConnectNotification` and `WebsocketDidDisconnectNotification` along with notifying delegate and calling `onConnect`/`onDisconnect`. Not the most popular use-case, but might be useful if one wants to observe socket state without taking away `delegate` from someone. 