### PR TITLE
Returned custom close reason from server according to RFC 6455

### DIFF
--- a/Source/WebSocket.swift
+++ b/Source/WebSocket.swift
@@ -588,17 +588,19 @@ public class WebSocket : NSObject, NSStreamDelegate {
                     }
                     offset += 2
                 }
+                var closeReason = "connection closed by server"
                 if payloadLen > 2 {
-                    let len = Int(payloadLen-2)
+                    let len = Int(payloadLen - 2)
                     if len > 0 {
                         let bytes = baseAddress + offset
-                        let str: NSString? = NSString(data: NSData(bytes: bytes, length: len), encoding: NSUTF8StringEncoding)
-                        if str == nil {
+                        if let customCloseReason = String(data: NSData(bytes: bytes, length: len), encoding: NSUTF8StringEncoding) {
+                            closeReason = customCloseReason
+                        } else {
                             code = CloseCode.ProtocolError.rawValue
                         }
                     }
                 }
-                doDisconnect(errorWithDetail("connection closed by server", code: code))
+                doDisconnect(errorWithDetail(closeReason, code: code))
                 writeError(code)
                 return emptyBuffer
             }


### PR DESCRIPTION
It appears to me as if this feature has been planned but not fully implemented. 
By actually using the parsed string we support close reason mentioned here: https://tools.ietf.org/html/rfc6455#section-7.1.6
