### PR TITLE
Fix typo in `dequeueInput`

### DIFF
--- a/Source/WebSocket.swift
+++ b/Source/WebSocket.swift
@@ -416,7 +416,7 @@ public class WebSocket : NSObject, StreamDelegate {
                 work = combine
                 self.fragBuffer = nil
             }
-            let buffer = UnsafePointer<UInt8>((data as NSData).bytes)
+            let buffer = UnsafePointer<UInt8>((work as NSData).bytes)
             let length = work.count
             if !connected {
                 processTCPHandshake(buffer, bufferLen: length)


### PR DESCRIPTION
This was breaking tcp messages that were sent in chunks, since only the first chunk would be processed.

As you can imagine, this one took quite a while to figure out... (in my case, I could only reproduce the error on a local network and not over a tcp tunnel, so I totally misdiagnosed it at first).