### PR TITLE
Added initializer to set the QOS of the write queue

### DIFF
--- a/Source/WebSocket.swift
+++ b/Source/WebSocket.swift
@@ -170,6 +170,12 @@ public class WebSocket: NSObject, NSStreamDelegate {
         writeQueue.maxConcurrentOperationCount = 1
         optionalProtocols = protocols
     }
+    
+    // Used for specifically setting the QOS for the write queue.
+    public convenience init(url: NSURL, writeQueueQOS: NSQualityOfService, protocols: [String]? = nil) {
+        self.init(url: url, protocols: protocols)
+        writeQueue.qualityOfService = writeQueueQOS
+    }
 
     /// Connect to the WebSocket server on a background thread.
     public func connect() {


### PR DESCRIPTION
Changes:
* Added an initializer to set the QOS of the write queue. We noticed in our project that the write queue was getting too backed up which would cause the app to not respond to the hardware quickly enough. This will allow the app side to decide whether it wants to override the default in case a higher or lower QOS is needed.