### PR TITLE
guarded self in async block

### DIFF
--- a/Source/WebSocket.swift
+++ b/Source/WebSocket.swift
@@ -324,11 +324,12 @@ public class WebSocket : NSObject, NSStreamDelegate {
         var timeout = 5000000 //wait 5 seconds before giving up
         writeQueue.addOperationWithBlock { [weak self] in
             while !outStream.hasSpaceAvailable {
+                guard let safeSelf = self else {return}
                 usleep(100) //wait until the socket is ready
                 timeout -= 100
                 if timeout < 0 {
-                    self?.cleanupStream()
-                    self?.doDisconnect(self?.errorWithDetail("write wait timed out", code: 2))
+                    safeSelf.cleanupStream()
+                    safeSelf.doDisconnect(safeSelf.errorWithDetail("write wait timed out", code: 2))
                     return
                 } else if outStream.streamError != nil {
                     return //disconnectStream will be called.


### PR DESCRIPTION
Fixed the bug that appeared in Crashlytics as:
Crashed: com.vluxe.starscream.websocket
EXC_BAD_ACCESS KERN_INVALID_ADDRESS 0x0000000000000010

Mentioned by a few others here:  
https://github.com/daltoniam/Starscream/issues?utf8=%E2%9C%93&q=com.vluxe.starscream.websocket