### PR TITLE
Enable custom trust validation

### DIFF
--- a/Source/SSLSecurity.swift
+++ b/Source/SSLSecurity.swift
@@ -23,6 +23,10 @@
 import Foundation
 import Security
 
+public protocol SSLTrustValidator {
+    func isValid(_ trust: SecTrust, domain: String?) -> Bool
+}
+
 open class SSLCert {
     var certData: Data?
     var key: SecKey?
@@ -50,7 +54,7 @@ open class SSLCert {
     }
 }
 
-open class SSLSecurity {
+open class SSLSecurity : SSLTrustValidator {
     public var validatedDN = true //should the domain name be validated?
     
     var isReady = false //is the key processing done?

--- a/Source/WebSocket.swift
+++ b/Source/WebSocket.swift
@@ -128,7 +128,7 @@ open class WebSocket : NSObject, StreamDelegate {
     public var headers = [String: String]()
     public var voipEnabled = false
     public var disableSSLCertValidation = false
-    public var security: SSLSecurity?
+    public var security: SSLTrustValidator?
     public var enabledSSLCipherSuites: [SSLCipherSuite]?
     public var origin: String?
     public var timeout = 5


### PR DESCRIPTION
In my project I need to perform special trust validation that is not covered by the existing SSLSecurity class. I saw that pull Request #266 opened all classes for subclassing but does not allow overriding of any of the methods.
So I change `WebSocket` to use a new protocol - `SSLTrustValidator` - for trust validation instead of `SSLSecurity` directly. This allows users of Starscream to supply their own validation logic if needed.