### PR TITLE
Remove the path components from the URL sent as origin

### DIFF
--- a/Source/WebSocket.swift
+++ b/Source/WebSocket.swift
@@ -166,7 +166,11 @@ open class WebSocket : NSObject, StreamDelegate {
     /// Used for setting protocols.
     public init(url: URL, protocols: [String]? = nil) {
         self.url = url
-        self.origin = url.absoluteString
+        if let hostUrl = URL (string: "/", relativeTo: url) {
+            var origin = hostUrl.absoluteString
+            origin.remove(at: origin.index(before: origin.endIndex))
+            self.origin = origin
+        }
         writeQueue.maxConcurrentOperationCount = 1
         optionalProtocols = protocols
     }

--- a/examples/SimpleTest/SimpleTest/ViewController.swift
+++ b/examples/SimpleTest/SimpleTest/ViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 import Starscream
 
 class ViewController: UIViewController, WebSocketDelegate {
-    var socket = WebSocket(url: URL(string: "ws://localhost:8080/")!, protocols: ["chat", "superchat"])
+    var socket = WebSocket(url: URL(string: "ws://localhost:8080/api")!, protocols: ["chat", "superchat"])
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/examples/SimpleTest/ws-server.rb
+++ b/examples/SimpleTest/ws-server.rb
@@ -8,7 +8,7 @@ EM.run {
       puts "origin: #{handshake.origin}"
       puts "headers: #{handshake.headers}"
 
-      ws.send "Hello Client, you connected to #{handshake.path}"
+      ws.send "Hello Client, you connected to #{handshake.path} with origin #{handshake.origin}"
     }
 
     ws.onerror do |error|


### PR DESCRIPTION
This fixes issue #287. The origin is a URI indicating the server from which the request initiated. It does not include any path information, but only the server name.