### PR TITLE
Prevent reconnection crash

### DIFF
--- a/Source/WebSocket.swift
+++ b/Source/WebSocket.swift
@@ -190,7 +190,6 @@ open class WebSocket : NSObject, StreamDelegate {
         didDisconnect = false
         isConnecting = true
         createHTTPRequest()
-        isConnecting = false
     }
 
     /**
@@ -494,6 +493,7 @@ open class WebSocket : NSObject, StreamDelegate {
         let code = processHTTP(buffer, bufferLen: bufferLen)
         switch code {
         case 0:
+            isConnecting = false
             connected = true
             guard canDispatch else {return}
             callbackQueue.async { [weak self] in
@@ -906,6 +906,7 @@ open class WebSocket : NSObject, StreamDelegate {
     private func doDisconnect(_ error: NSError?) {
         guard !didDisconnect else { return }
         didDisconnect = true
+        isConnecting = false
         connected = false
         guard canDispatch else {return}
         callbackQueue.async { [weak self] in

--- a/Source/WebSocket.swift
+++ b/Source/WebSocket.swift
@@ -318,6 +318,9 @@ open class WebSocket : NSObject, StreamDelegate {
         //higher level API we will cut over to at some point
         //NSStream.getStreamsToHostWithName(url.host, port: url.port.integerValue, inputStream: &inputStream, outputStream: &outputStream)
 
+        // Disconnect and clean up any existing streams before setting up a new pair
+        disconnectStream(nil)
+
         var readStream: Unmanaged<CFReadStream>?
         var writeStream: Unmanaged<CFWriteStream>?
         let h = url.host! as NSString


### PR DESCRIPTION
There are a couple cases where a socket would create a new connection without closing an existing one.

1. Between the time when the socket opens the streams until the TCP handshake ends, it would be both `!connected` and `!isConnecting`, so a second `connect` would go through creating a new pair of streams without disconnecting the first pair.
2. Since `disconnect` without a timeout only sends a close message to the server, if we tried to `connect` the socket again before the connection was closed it would not disconnect the previous streams.

In any of those cases we end up with a `NSInputStream` that still has the `WebSocket` as a delegate, but it's no longer referenced in `inputStream`. If the `WebSocket` is deallocated, it wouldn't clean up the delegate on that stream, and if it received any data, it would try to forward it to a deallocated object, which would crash.

This should fix #272 