### PR TITLE
Added guard against multiple disconnects

### DIFF
--- a/Source/WebSocket.swift
+++ b/Source/WebSocket.swift
@@ -203,6 +203,7 @@ open class WebSocket : NSObject, StreamDelegate {
      - Parameter closeCode: The code to send on disconnect. The default is the normal close code for cleanly disconnecting a webSocket.
     */
     open func disconnect(forceTimeout: TimeInterval? = nil, closeCode: UInt16 = CloseCode.normal.rawValue) {
+        guard isConnected else { return }
         switch forceTimeout {
         case .some(let seconds) where seconds > 0:
             let milliseconds = Int(seconds * 1_000)


### PR DESCRIPTION
I was noticing issues where my app would send multiple disconnect frames. It seemed appropriate for the library to guard against this. (Although there's an argument to be made that avoiding unnecessary calls to disconnect is the responsibility of whomever is using the library...)

I should also note that I was having trouble with running the tests, as stated in issue #297. Let me know if there's any test failures.

@daltoniam Please review. 