### PR TITLE
Avoid a warning caused by len < 0 where len is an UInt64

### DIFF
--- a/Source/WebSocket.swift
+++ b/Source/WebSocket.swift
@@ -704,17 +704,13 @@ open class WebSocket : NSObject, StreamDelegate {
                 len = UInt64(bufferLen-offset)
             }
             let data: Data
-            if len < 0 {
-                len = 0
-                data = Data()
-            } else {
-                if receivedOpcode == .connectionClose && len > 0 {
-                    let size = MemoryLayout<UInt16>.size
-                    offset += size
-                    len -= UInt64(size)
-                }
-                data = Data(bytes: baseAddress+offset, count: Int(len))
-            }
+			if receivedOpcode == .connectionClose && len > 0 {
+				let size = MemoryLayout<UInt16>.size
+				offset += size
+				len -= UInt64(size)
+			}
+			data = Data(bytes: baseAddress+offset, count: Int(len))
+
             if receivedOpcode == .connectionClose {
                 var closeReason = "connection closed by server"
                 if let customCloseReason = String(data: data, encoding: .utf8) {

--- a/Source/WebSocket.swift
+++ b/Source/WebSocket.swift
@@ -644,7 +644,8 @@ open class WebSocket : NSObject, StreamDelegate {
             return buffer.fromOffset(bufferLen - extra)
         } else {
             let isFin = (FinMask & baseAddress[0])
-            let receivedOpcode = OpCode(rawValue: (OpCodeMask & baseAddress[0]))
+			let receivedOpcodeRawValue = (OpCodeMask & baseAddress[0])
+            let receivedOpcode = OpCode(rawValue: receivedOpcodeRawValue)
             let isMasked = (MaskMask & baseAddress[1])
             let payloadLen = (PayloadLenMask & baseAddress[1])
             var offset = 2
@@ -658,7 +659,7 @@ open class WebSocket : NSObject, StreamDelegate {
             if !isControlFrame && (receivedOpcode != .binaryFrame && receivedOpcode != .continueFrame &&
                 receivedOpcode != .textFrame && receivedOpcode != .pong) {
                     let errCode = CloseCode.protocolError.rawValue
-                    doDisconnect(errorWithDetail("unknown opcode: \(receivedOpcode)", code: errCode))
+                    doDisconnect(errorWithDetail("unknown opcode: \(receivedOpcodeRawValue)", code: errCode))
                     writeError(errCode)
                     return emptyBuffer
             }


### PR DESCRIPTION
When using Xcode 8.3b5, you will see a warning due to the comparison len < 0 where len is an UInt64.