### PR TITLE
Remove void parameter from onConnect, Swift4 would require passi…

### DIFF
--- a/Source/WebSocket.swift
+++ b/Source/WebSocket.swift
@@ -119,7 +119,7 @@ open class WebSocket : NSObject, StreamDelegate {
 
     // MARK: - Block based API.
 
-    public var onConnect: ((Void) -> Void)?
+    public var onConnect: (() -> Void)?
     public var onDisconnect: ((NSError?) -> Void)?
     public var onText: ((String) -> Void)?
     public var onData: ((Data) -> Void)?


### PR DESCRIPTION
…ng () into it

@daltoniam Noticed in the Swift 4 preview that this would require passing `()` into the onConnect callback, which is a bit funky.