### PR TITLE
SecTrust object now is conditionally unwrapped

### DIFF
--- a/Source/WebSocket.swift
+++ b/Source/WebSocket.swift
@@ -455,9 +455,12 @@ open class WebSocket : NSObject, StreamDelegate {
             guard !sOperation.isCancelled, let s = self else { return }
             // Do the pinning now if needed
             if let sec = s.security, !s.certValidated {
-                let trust = outStream.property(forKey: kCFStreamPropertySSLPeerTrust as Stream.PropertyKey) as! SecTrust
-                let domain = outStream.property(forKey: kCFStreamSSLPeerName as Stream.PropertyKey) as? String
-                s.certValidated = sec.isValid(trust, domain: domain)
+                if let possibleTrust = outStream.property(forKey: kCFStreamPropertySSLPeerTrust as Stream.PropertyKey) {
+                    let domain = outStream.property(forKey: kCFStreamSSLPeerName as Stream.PropertyKey) as? String
+                    s.certValidated = sec.isValid(possibleTrust as! SecTrust, domain: domain)
+                } else {
+                    s.certValidated = false
+                }
                 if !s.certValidated {
                     WebSocket.sharedWorkQueue.async {
                         let errCode = InternalErrorCode.invalidSSLError.rawValue


### PR DESCRIPTION
This PR fixes an issue introduced by https://github.com/daltoniam/Starscream/commit/dbeb1190b8dcbff4f0b797f9e9d9b9b864d1f0d6#diff-b9ab27dc605d36ce558013387d2ba2d5

Now the SecTrust object is conditionally unwrapped and if not found , the pinning will fail*. I was never able to reproduce the scenario where the SecTrust object is null within a wss/https connection, i think this could be related to a failed SSL handshake (maybe due to networking issues) but these are just speculations at this point.

* I consider the pinning failed, because if you end up in that code branch it's because: 
1. the url is either wss or https
2. a security object was provided to perform the certificate pinning
the client is clearly signalling is will for the pinning to be performed, so in absence of a trust that contains the certificates to be checked, i think it's better to reject the connection