### PR TITLE
off-by-one bug

### DIFF
--- a/Source/WebSocket.swift
+++ b/Source/WebSocket.swift
@@ -595,7 +595,7 @@ open class WebSocket : NSObject, StreamDelegate {
         for i in 0..<bufferLen {
             if buffer[i] == CRLFBytes[k] {
                 k += 1
-                if k == 3 {
+                if k == 4 {
                     totalSize = i + 1
                     break
                 }


### PR DESCRIPTION
if the header is
"HTTP/1.1 440 Client Error (440)\r\n\r\n{"api:statuscode": 105, "api:message": "Invalid session. Please re-login."}"
the validateResponse() returns 200, but 440 expected