### PR TITLE
Fix warning for Swift 4 on the use of `character` property

### DIFF
--- a/Sources/WebSocket.swift
+++ b/Sources/WebSocket.swift
@@ -252,7 +252,7 @@ open class FoundationStream : NSObject, WSStream, StreamDelegate  {
             let _ = peerName.withUnsafeMutableBytes { (peerNamePtr: UnsafeMutablePointer<Int8>) in
                 SSLGetPeerDomainName(sslContextOut, peerNamePtr, &peerNameLen)
             }
-            if let peerDomain = String(bytes: peerName, encoding: .utf8), peerDomain.characters.count > 0 {
+            if let peerDomain = String(bytes: peerName, encoding: .utf8), peerDomain.count > 0 {
                 domain = peerDomain
             }
         }


### PR DESCRIPTION
Hi,

This PR fixes a warning on Xcode 9 / Swift 4 for using the `characters` property.

