### PR TITLE
Fix invalid NSError instance

### DIFF
--- a/Sources/Compression.swift
+++ b/Sources/Compression.swift
@@ -52,7 +52,7 @@ class Decompressor {
 
     func reset() throws {
         teardownInflate()
-        guard initInflate() else { throw NSError() }
+        guard initInflate() else { throw NSError(domain: WebSocket.ErrorDomain, code: Int(InternalErrorCode.initError.rawValue), userInfo: nil) }
     }
 
     func decompress(_ data: Data, finish: Bool) throws -> Data {
@@ -131,7 +131,7 @@ class Compressor {
 
     func reset() throws {
         teardownDeflate()
-        guard initDeflate() else { throw NSError() }
+        guard initDeflate() else { throw NSError(domain: WebSocket.ErrorDomain, code: Int(InternalErrorCode.initError.rawValue), userInfo: nil) }
     }
 
     func compress(_ data: Data) throws -> Data {

--- a/Sources/WebSocket.swift
+++ b/Sources/WebSocket.swift
@@ -48,6 +48,7 @@ enum InternalErrorCode: UInt16 {
     case compressionError = 2
     case invalidSSLError = 3
     case writeTimeoutError = 4
+    case initError = 5
 }
 
 //WebSocketClient is setup to be dependency injection for testing


### PR DESCRIPTION
Calling default init on NSError now throws an exception (Xcode 9.2)
Warning Message: `-[NSError init] called; this results in an invalid NSError instance. It will raise an exception in a future release. Please call errorWithDomain:code:userInfo: or initWithDomain:code:userInfo:. This message shown only once.`