### PR TITLE
Linux port using IBM's libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 # Xcode
 .DS_Store
 build
+.build
 *.pbxuser
 !default.pbxuser
 *.mode1v3

--- a/Package.resolved
+++ b/Package.resolved
@@ -36,6 +36,15 @@
           "revision": "2eb3aff0fb57f92f5722fac5d6d20bf64669ca66",
           "version": "1.1.0"
         }
+      },
+      {
+        "package": "Socket",
+        "repositoryURL": "https://github.com/IBM-Swift/BlueSocket",
+        "state": {
+          "branch": null,
+          "revision": "0dacaaa9482871142cb8dc869cf4b80396450e16",
+          "version": "0.12.86"
+        }
       }
     ]
   },

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,43 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "CommonCrypto",
+        "repositoryURL": "https://github.com/IBM-Swift/CommonCrypto.git",
+        "state": {
+          "branch": null,
+          "revision": "9156d238dbc4c15455b77b45e721b2bb0b995e31",
+          "version": "0.1.5"
+        }
+      },
+      {
+        "package": "Cryptor",
+        "repositoryURL": "https://github.com/IBM-Swift/BlueCryptor",
+        "state": {
+          "branch": null,
+          "revision": "12f9be466d1166b16da8cb2a9d549098990248d1",
+          "version": "0.8.25"
+        }
+      },
+      {
+        "package": "SSCZLib",
+        "repositoryURL": "https://github.com/daltoniam/zlib-spm.git",
+        "state": {
+          "branch": null,
+          "revision": "83ac8d719a2f3aa775dbdf116a57f56fb2c49abb",
+          "version": "1.1.0"
+        }
+      },
+      {
+        "package": "SSCommonCrypto",
+        "repositoryURL": "https://github.com/daltoniam/common-crypto-spm",
+        "state": {
+          "branch": null,
+          "revision": "2eb3aff0fb57f92f5722fac5d6d20bf64669ca66",
+          "version": "1.1.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -27,6 +27,8 @@ let package = Package(
     majorVersion: 1, minor: 1),
         .Package(url: "https://github.com/daltoniam/common-crypto-spm",
                  majorVersion: 1, minor: 1),
+        .Package(url: "https://github.com/IBM-Swift/BlueCryptor",
+                 majorVersion: 0, minor: 8),
         ],
     exclude: ["Tests", "examples"]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -29,6 +29,8 @@ let package = Package(
                  majorVersion: 1, minor: 1),
         .Package(url: "https://github.com/IBM-Swift/BlueCryptor",
                  majorVersion: 0, minor: 8),
+        .Package(url: "https://github.com/IBM-Swift/BlueSocket",
+                 majorVersion: 0, minor: 12)
         ],
     exclude: ["Tests", "examples"]
 )

--- a/Sources/WebSocket.swift
+++ b/Sources/WebSocket.swift
@@ -822,7 +822,7 @@ open class WebSocket : NSObject, WebSocketClient, WSStreamDelegate {
             work = combine
             fragBuffer = nil
         }
-        let buffer = UnsafeRawPointer((work as NSData).bytes).assumingMemoryBound(to: UInt8.self)
+        let buffer = UnsafeRawPointer((work as NSData).bytes).assumingMemoryBound(to: UInt8)
         let length = work.count
         if !connected {
             processTCPHandshake(buffer, bufferLen: length)

--- a/Sources/WebSocket.swift
+++ b/Sources/WebSocket.swift
@@ -203,8 +203,8 @@ open class FoundationStream : NSObject, WSStream, StreamDelegate  {
             #endif
         }
         
-        CFReadStreamSetDispatchQueue(unsafeBitCast(inStream, to: CFReadStream.self), FoundationStream.sharedWorkQueue)
-        CFWriteStreamSetDispatchQueue(unsafeBitCast(outStream, to: CFWriteStream.self), FoundationStream.sharedWorkQueue)
+        CFReadStreamSetDispatchQueue(inStream as CFReadStream, FoundationStream.sharedWorkQueue)
+        CFWriteStreamSetDispatchQueue(outStream as CFWriteStream, FoundationStream.sharedWorkQueue)
         inStream.open()
         outStream.open()
         
@@ -230,7 +230,7 @@ open class FoundationStream : NSObject, WSStream, StreamDelegate  {
     
     public func write(data: Data) -> Int {
         guard let outStream = outputStream else {return -1}
-        let buffer = UnsafeRawPointer((data as NSData).bytes).assumingMemoryBound(to: UInt8.self)
+        let buffer = UnsafeMutableRawPointer(mutating: (data as NSData).bytes).assumingMemoryBound(to: UInt8.self)
         return outStream.write(buffer, maxLength: data.count)
     }
     

--- a/Sources/WebSocket.swift
+++ b/Sources/WebSocket.swift
@@ -1348,7 +1348,7 @@ open class WebSocket : NSObject, WebSocketClient, WSStreamDelegate {
             s.delegate?.websocketDidDisconnect(socket: s, error: error)
             s.advancedDelegate?.websocketDidDisconnect(socket: s, error: error)
             let userInfo = error.map{ [WebsocketDisconnectionErrorKeyName: $0] }
-            NotificationCenter.default.post(name: NSNotification.Name(WebsocketDidDisconnectNotification), object: self, userInfo: userInfo)
+            NotificationCenter.default.post(name: NSNotification.Name(rawValue: WebsocketDidDisconnectNotification), object: self, userInfo: userInfo)
         }
     }
 

--- a/Sources/WebSocket.swift
+++ b/Sources/WebSocket.swift
@@ -670,7 +670,7 @@ open class WebSocket : NSObject, WebSocketClient, WSStreamDelegate {
         let randomBytes = try! Random.generate(byteCount: 16)
         var key = ""
         for byte in randomBytes {
-            let uni = UnicodeScalar(UInt32(97 + byte))
+            let uni = UnicodeScalar(UInt32(byte))
             key += "\(Character(uni!))"
         }
         let data = key.data(using: String.Encoding.utf8)
@@ -1216,7 +1216,7 @@ open class WebSocket : NSObject, WebSocketClient, WSStreamDelegate {
                     dequeueWrite(unsafeBitCast(data, to: Data.self), code: .pong)
                 }
             } else if response.code == .textFrame {
-                guard let str = String(data: unsafeBitCast(response.buffer!, to: Data.self), encoding: .utf8) else {
+                guard let str = String(data: response.buffer!.copy() as! Data, encoding: .utf8) else {
                     writeError(CloseCode.encoding.rawValue)
                     return false
                 }

--- a/Sources/WebSocket.swift
+++ b/Sources/WebSocket.swift
@@ -21,7 +21,7 @@
 
 import Foundation
 import CoreFoundation
-import SSCommonCrypto
+import Cryptor
 
 public let WebsocketDidConnectNotification = "WebsocketDidConnectNotification"
 public let WebsocketDidDisconnectNotification = "WebsocketDidDisconnectNotification"
@@ -1310,8 +1310,7 @@ open class WebSocket : NSObject, StreamDelegate, WebSocketClient, WSStreamDelega
 private extension String {
     func sha1Base64() -> String {
         let data = self.data(using: String.Encoding.utf8)!
-        var digest = [UInt8](repeating: 0, count:Int(CC_SHA1_DIGEST_LENGTH))
-        data.withUnsafeBytes { _ = CC_SHA1($0, CC_LONG(data.count), &digest) }
+        let digest = Digest(using: .sha1).update(data: data)?.final()!
         return Data(bytes: digest).base64EncodedString()
     }
 }

--- a/Sources/WebSocket.swift
+++ b/Sources/WebSocket.swift
@@ -1310,8 +1310,8 @@ open class WebSocket : NSObject, StreamDelegate, WebSocketClient, WSStreamDelega
 private extension String {
     func sha1Base64() -> String {
         let data = self.data(using: String.Encoding.utf8)!
-        let digest = Digest(using: .sha1).update(data: data)?.final()!
-        return Data(bytes: digest).base64EncodedString()
+        let digest = Digest(using: .sha1).update(data: data)?.final()
+        return Data(bytes: digest!).base64EncodedString()
     }
 }
 

--- a/Sources/WebSocket.swift
+++ b/Sources/WebSocket.swift
@@ -665,7 +665,7 @@ open class WebSocket : NSObject, WebSocketClient, WSStreamDelegate {
                 s.disconnectStream(error)
                 return
             }
-            let operation = BlockOperation()
+            let operation = BlockOperation(block: { })
             operation.addExecutionBlock { [weak self, weak operation] in
                 guard let sOperation = operation, let s = self else { return }
                 guard !sOperation.isCancelled else { return }

--- a/Sources/WebSocket.swift
+++ b/Sources/WebSocket.swift
@@ -147,7 +147,7 @@ open class FoundationStream : NSObject, WSStream, StreamDelegate  {
         var readStream: Unmanaged<CFReadStream>?
         var writeStream: Unmanaged<CFWriteStream>?
         let h = NSString(string: url.host!)
-        CFStreamCreatePairWithSocketToHost(nil, h, UInt32(port), &readStream, &writeStream)
+        CFStreamCreatePairWithSocketToHost(nil, unsafeBitCast(h, to: CFString.self), UInt32(port), &readStream, &writeStream)
         inputStream = unsafeBitCast(readStream!.takeRetainedValue(), to: InputStream.self)
         outputStream = unsafeBitCast(writeStream!.takeRetainedValue(), to: OutputStream.self)
 
@@ -203,8 +203,8 @@ open class FoundationStream : NSObject, WSStream, StreamDelegate  {
             #endif
         }
         
-        CFReadStreamSetDispatchQueue(inStream, FoundationStream.sharedWorkQueue)
-        CFWriteStreamSetDispatchQueue(outStream, FoundationStream.sharedWorkQueue)
+        CFReadStreamSetDispatchQueue(unsafeBitCast(inStream, to: CFReadStream.self), FoundationStream.sharedWorkQueue)
+        CFWriteStreamSetDispatchQueue(unsafeBitCast(outStream, to: CFWriteStream.self), FoundationStream.sharedWorkQueue)
         inStream.open()
         outStream.open()
         

--- a/Sources/WebSocket.swift
+++ b/Sources/WebSocket.swift
@@ -817,7 +817,7 @@ open class WebSocket : NSObject, WebSocketClient, WSStreamDelegate {
         let data = inputQueue[0]
         var work = data
         if let buffer = fragBuffer {
-            var combine = NSData(data: buffer) as Data
+            var combine = unsafeBitCast(NSData(data: buffer), to: Data.self)
             combine.append(data)
             work = combine
             fragBuffer = nil
@@ -1257,7 +1257,7 @@ open class WebSocket : NSObject, WebSocketClient, WSStreamDelegate {
      Used to write things to the stream
      */
     private func dequeueWrite(_ data: Data, code: OpCode, writeCompletion: (() -> ())? = nil) {
-        let operation = BlockOperation()
+        let operation = BlockOperation(block: {})
         operation.addExecutionBlock { [weak self, weak operation] in
             //stream isn't ready, let's wait
             guard let s = self else { return }

--- a/Sources/WebSocket.swift
+++ b/Sources/WebSocket.swift
@@ -135,8 +135,8 @@ public protocol WSStream {
     #endif
 }
 
-#if os(Linux)
 open class BlueSocketStream : NSObject, WSStream  {
+
     public var delegate: WSStreamDelegate?
     var socket: Socket?
 
@@ -169,8 +169,13 @@ open class BlueSocketStream : NSObject, WSStream  {
     public func cleanup() {
         socket?.close()
     }
+
+    public func sslTrust() -> (trust: SecTrust?, domain: String?) {
+        return (trust: nil, domain: nil)
+    }
 }
-#else
+
+#if !os(Linux)
 open class FoundationStream : NSObject, WSStream, StreamDelegate  {
     private static let sharedWorkQueue = DispatchQueue(label: "com.vluxe.starscream.websocket", attributes: [])
     private var inputStream: InputStream?
@@ -339,11 +344,11 @@ open class FoundationStream : NSObject, WSStream, StreamDelegate  {
 
 class WSStreamFactory {
     public static func make() -> WSStream {
-        #if os(Linux)
+//        #if os(Linux)
             return BlueSocketStream()
-        #else
-            return FoundationStream()
-        #endif
+//        #else
+//            return FoundationStream()
+//        #endif
     }
 }
 

--- a/Sources/WebSocket.swift
+++ b/Sources/WebSocket.swift
@@ -136,7 +136,7 @@ public protocol WSStream {
 }
 
 #if os(Linux)
-open class BlueSocketStream : NSObject, WSStream, StreamDelegate  {
+open class BlueSocketStream : NSObject, WSStream  {
     public var delegate: WSStreamDelegate?
     var socket: Socket?
 
@@ -167,7 +167,7 @@ open class BlueSocketStream : NSObject, WSStream, StreamDelegate  {
     }
 
     public func cleanup() {
-        socket.close()
+        socket?.close()
     }
 }
 #else

--- a/Sources/WebSocket.swift
+++ b/Sources/WebSocket.swift
@@ -1293,7 +1293,9 @@ open class WebSocket : NSObject, WebSocketClient, WSStreamDelegate {
             }
             buffer[1] |= s.MaskMask
             let maskKey = UnsafeMutablePointer<UInt8>(buffer + offset)
-            _ = SecRandomCopyBytes(kSecRandomDefault, Int(MemoryLayout<UInt32>.size), maskKey)
+
+            let randomBytes = try! Random.generate(byteCount: Int(MemoryLayout<UInt32>.size))
+            maskKey.pointee = randomBytes.first!
             offset += MemoryLayout<UInt32>.size
 
             for i in 0..<dataLength {

--- a/Sources/WebSocket.swift
+++ b/Sources/WebSocket.swift
@@ -203,8 +203,8 @@ open class FoundationStream : NSObject, WSStream, StreamDelegate  {
             #endif
         }
         
-        CFReadStreamSetDispatchQueue(inStream as CFReadStream, FoundationStream.sharedWorkQueue)
-        CFWriteStreamSetDispatchQueue(outStream as CFWriteStream, FoundationStream.sharedWorkQueue)
+        CFReadStreamSetDispatchQueue(unsafeBitCast(inStream, to: CFReadStream.self), FoundationStream.sharedWorkQueue)
+        CFWriteStreamSetDispatchQueue(unsafeBitCast(outStream, to: CFWriteStream.self), FoundationStream.sharedWorkQueue)
         inStream.open()
         outStream.open()
         
@@ -249,12 +249,12 @@ open class FoundationStream : NSObject, WSStream, StreamDelegate  {
     public func cleanup() {
         if let stream = inputStream {
             stream.delegate = nil
-            CFReadStreamSetDispatchQueue(stream, nil)
+            CFReadStreamSetDispatchQueue(unsafeBitCast(stream, to: CFReadStream.self), nil)
             stream.close()
         }
         if let stream = outputStream {
             stream.delegate = nil
-            CFWriteStreamSetDispatchQueue(stream, nil)
+            CFWriteStreamSetDispatchQueue(unsafeBitCast(stream,to: CFWriteStream.self), nil)
             stream.close()
         }
         outputStream = nil

--- a/Sources/WebSocket.swift
+++ b/Sources/WebSocket.swift
@@ -822,14 +822,16 @@ open class WebSocket : NSObject, WebSocketClient, WSStreamDelegate {
             work = combine
             fragBuffer = nil
         }
-        let buffer = UnsafeRawPointer((work as NSData).bytes).assumingMemoryBound(to: UInt8)
-        let length = work.count
-        if !connected {
-            processTCPHandshake(buffer, bufferLen: length)
-        } else {
-            processRawMessagesInBuffer(buffer, bufferLen: length)
+        work.withUnsafeMutableBytes { (unsafePointer: UnsafeMutablePointer<UInt8>) -> Int in
+            let length = work.count
+            if !connected {
+                processTCPHandshake(unsafePointer, bufferLen: length)
+            } else {
+                processRawMessagesInBuffer(unsafePointer, bufferLen: length)
+            }
+            inputQueue = inputQueue.filter{ $0 != data }
+            return 0
         }
-        inputQueue = inputQueue.filter{ $0 != data }
     }
 
     /**

--- a/Sources/WebSocket.swift
+++ b/Sources/WebSocket.swift
@@ -619,10 +619,10 @@ open class WebSocket : NSObject, WebSocketClient, WSStreamDelegate {
      Generate a WebSocket key as needed in RFC.
      */
     private func generateWebSocketKey() -> String {
+        let randomBytes = try! Random.generate(byteCount: 16)
         var key = ""
-        let seed = 16
-        for _ in 0..<seed {
-            let uni = UnicodeScalar(UInt32(97 + arc4random_uniform(25)))
+        for byte in randomBytes {
+            let uni = UnicodeScalar(UInt32(97 + byte))
             key += "\(Character(uni!))"
         }
         let data = key.data(using: String.Encoding.utf8)

--- a/Sources/WebSocket.swift
+++ b/Sources/WebSocket.swift
@@ -327,7 +327,7 @@ public protocol WebSocketAdvancedDelegate: class {
 }
 
 
-open class WebSocket : NSObject, StreamDelegate, WebSocketClient, WSStreamDelegate {
+open class WebSocket : NSObject, WebSocketClient, WSStreamDelegate {
 
     public enum OpCode : UInt8 {
         case continueFrame = 0x0

--- a/Sources/WebSocket.swift
+++ b/Sources/WebSocket.swift
@@ -230,8 +230,9 @@ open class FoundationStream : NSObject, WSStream, StreamDelegate  {
     
     public func write(data: Data) -> Int {
         guard let outStream = outputStream else {return -1}
-        let buffer = UnsafeMutableRawPointer(mutating: (data as NSData).bytes).assumingMemoryBound(to: UInt8.self)
-        return outStream.write(buffer, maxLength: data.count)
+        return data.withUnsafeBytes { buffer in
+            outStream.write(buffer, maxLength: data.count)
+        }
     }
     
     public func read() -> Data? {

--- a/Sources/WebSocket.swift
+++ b/Sources/WebSocket.swift
@@ -21,6 +21,7 @@
 
 import Foundation
 import CoreFoundation
+import Dispatch
 import Cryptor
 
 public let WebsocketDidConnectNotification = "WebsocketDidConnectNotification"

--- a/Sources/WebSocket.swift
+++ b/Sources/WebSocket.swift
@@ -146,7 +146,7 @@ open class FoundationStream : NSObject, WSStream, StreamDelegate  {
     public func connect(url: URL, port: Int, timeout: TimeInterval, ssl: SSLSettings, completion: @escaping ((Error?) -> Void)) {
         var readStream: Unmanaged<CFReadStream>?
         var writeStream: Unmanaged<CFWriteStream>?
-        let h = url.host! as NSString
+        let h = NSString(string: url.host!)
         CFStreamCreatePairWithSocketToHost(nil, h, UInt32(port), &readStream, &writeStream)
         inputStream = readStream!.takeRetainedValue()
         outputStream = writeStream!.takeRetainedValue()
@@ -176,7 +176,7 @@ open class FoundationStream : NSObject, WSStream, StreamDelegate  {
                 }
                 if ssl.overrideTrustHostname {
                     if let hostname = ssl.desiredTrustHostname {
-                        settings[kCFStreamSSLPeerName] = hostname as NSString
+                        settings[kCFStreamSSLPeerName] = NSString(string: hostname)
                     } else {
                         settings[kCFStreamSSLPeerName] = kCFNull
                     }

--- a/Starscream.xcodeproj/project.pbxproj
+++ b/Starscream.xcodeproj/project.pbxproj
@@ -44,14 +44,14 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		B4A3C2762019D718003EC7DF /* PBXContainerItemProxy */ = {
+		B4A3C2782019DCE3003EC7DF /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "Socket::Socket";
 			remoteInfo = Socket;
 		};
-		B4A3C2772019D718003EC7DF /* PBXContainerItemProxy */ = {
+		B4A3C2792019DCE3003EC7DF /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
@@ -405,12 +405,12 @@
 		OBJ_67 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "Socket::Socket" /* Socket */;
-			targetProxy = B4A3C2762019D718003EC7DF /* PBXContainerItemProxy */;
+			targetProxy = B4A3C2782019DCE3003EC7DF /* PBXContainerItemProxy */;
 		};
 		OBJ_69 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "Cryptor::Cryptor" /* Cryptor */;
-			targetProxy = B4A3C2772019D718003EC7DF /* PBXContainerItemProxy */;
+			targetProxy = B4A3C2792019DCE3003EC7DF /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 

--- a/Starscream.xcodeproj/project.pbxproj
+++ b/Starscream.xcodeproj/project.pbxproj
@@ -44,14 +44,14 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		B4A3C2782019DCE3003EC7DF /* PBXContainerItemProxy */ = {
+		B4A3C2A02019E0CF003EC7DF /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "Socket::Socket";
 			remoteInfo = Socket;
 		};
-		B4A3C2792019DCE3003EC7DF /* PBXContainerItemProxy */ = {
+		B4A3C2A12019E0CF003EC7DF /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
@@ -405,12 +405,12 @@
 		OBJ_67 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "Socket::Socket" /* Socket */;
-			targetProxy = B4A3C2782019DCE3003EC7DF /* PBXContainerItemProxy */;
+			targetProxy = B4A3C2A02019E0CF003EC7DF /* PBXContainerItemProxy */;
 		};
 		OBJ_69 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "Cryptor::Cryptor" /* Cryptor */;
-			targetProxy = B4A3C2792019DCE3003EC7DF /* PBXContainerItemProxy */;
+			targetProxy = B4A3C2A12019E0CF003EC7DF /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 

--- a/Starscream.xcodeproj/project.pbxproj
+++ b/Starscream.xcodeproj/project.pbxproj
@@ -6,518 +6,747 @@
 	objectVersion = 46;
 	objects = {
 
+/* Begin PBXAggregateTarget section */
+		"CommonCrypto::CommonCrypto::ProductTarget" /* CommonCrypto */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = OBJ_95 /* Build configuration list for PBXAggregateTarget "CommonCrypto" */;
+			buildPhases = (
+			);
+			dependencies = (
+			);
+			name = CommonCrypto;
+			productName = CommonCrypto;
+		};
+/* End PBXAggregateTarget section */
+
 /* Begin PBXBuildFile section */
-		335FA1F61F5DF71D00F6D2EC /* Compression.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88EAF7E1ED4DFB5004FE2C3 /* Compression.swift */; };
-		335FA1F71F5DF71D00F6D2EC /* SSLSecurity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C135FFF1C473BEF00AA3A01 /* SSLSecurity.swift */; };
-		335FA1F81F5DF71D00F6D2EC /* WebSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C1360011C473BEF00AA3A01 /* WebSocket.swift */; };
-		335FA1F91F5DF71D00F6D2EC /* CompressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88EAF831ED4E7D8004FE2C3 /* CompressionTests.swift */; };
-		335FA1FA1F5DF71D00F6D2EC /* StarscreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 742419BB1DC6BDBA003ACE43 /* StarscreamTests.swift */; };
-		335FA1FC1F5DF71D00F6D2EC /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = D88EAF811ED4DFD3004FE2C3 /* libz.tbd */; };
-		33CCF0861F5DDC030099B092 /* Compression.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88EAF7E1ED4DFB5004FE2C3 /* Compression.swift */; };
-		33CCF0871F5DDC030099B092 /* WebSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C1360011C473BEF00AA3A01 /* WebSocket.swift */; };
-		33CCF0881F5DDC030099B092 /* SSLSecurity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C135FFF1C473BEF00AA3A01 /* SSLSecurity.swift */; };
-		33CCF08A1F5DDC030099B092 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = D88EAF811ED4DFD3004FE2C3 /* libz.tbd */; };
-		33CCF08C1F5DDC030099B092 /* Starscream.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C1360001C473BEF00AA3A01 /* Starscream.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		33CCF08D1F5DDC030099B092 /* include.h in Headers */ = {isa = PBXBuildFile; fileRef = D85927D71ED76F25003460CB /* include.h */; };
+		OBJ_43 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
+		OBJ_49 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_20 /* Package.swift */; };
+		OBJ_55 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_33 /* Package.swift */; };
+		OBJ_61 /* Compression.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_8 /* Compression.swift */; };
+		OBJ_62 /* SSLSecurity.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_9 /* SSLSecurity.swift */; };
+		OBJ_63 /* WebSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_10 /* WebSocket.swift */; };
+		OBJ_65 /* Socket.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Socket::Socket::Product" /* Socket.framework */; };
+		OBJ_66 /* Cryptor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Cryptor::Cryptor::Product" /* Cryptor.framework */; };
+		OBJ_75 /* Socket.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_17 /* Socket.swift */; };
+		OBJ_76 /* SocketProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_18 /* SocketProtocols.swift */; };
+		OBJ_77 /* SocketUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_19 /* SocketUtils.swift */; };
+		OBJ_83 /* Crypto.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_23 /* Crypto.swift */; };
+		OBJ_84 /* Cryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_24 /* Cryptor.swift */; };
+		OBJ_85 /* Digest.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_25 /* Digest.swift */; };
+		OBJ_86 /* HMAC.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_26 /* HMAC.swift */; };
+		OBJ_87 /* KeyDerivation.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_27 /* KeyDerivation.swift */; };
+		OBJ_88 /* Random.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_28 /* Random.swift */; };
+		OBJ_89 /* Status.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_29 /* Status.swift */; };
+		OBJ_90 /* StreamCryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_30 /* StreamCryptor.swift */; };
+		OBJ_91 /* Updatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_31 /* Updatable.swift */; };
+		OBJ_92 /* Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_32 /* Utilities.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		B4A3C2762019D718003EC7DF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "Socket::Socket";
+			remoteInfo = Socket;
+		};
+		B4A3C2772019D718003EC7DF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "Cryptor::Cryptor";
+			remoteInfo = Cryptor;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
-		335FA2021F5DF71D00F6D2EC /* Starscream Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Starscream Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
-		33CCF0921F5DDC030099B092 /* Starscream.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Starscream.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		5C135FFF1C473BEF00AA3A01 /* SSLSecurity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SSLSecurity.swift; path = Sources/SSLSecurity.swift; sourceTree = SOURCE_ROOT; };
-		5C1360001C473BEF00AA3A01 /* Starscream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Starscream.h; path = Sources/Starscream.h; sourceTree = SOURCE_ROOT; };
-		5C1360011C473BEF00AA3A01 /* WebSocket.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = WebSocket.swift; path = Sources/WebSocket.swift; sourceTree = SOURCE_ROOT; };
-		5C13600C1C473BFE00AA3A01 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Sources/Info.plist; sourceTree = SOURCE_ROOT; };
-		5CAAB5D01F7987D800F3C556 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = Platforms/WatchOS.platform/Developer/SDKs/WatchOS4.0.sdk/usr/lib/libz.tbd; sourceTree = DEVELOPER_DIR; };
-		6B3E7A0019D48C2F006071F7 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		742419BB1DC6BDBA003ACE43 /* StarscreamTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = StarscreamTests.swift; path = StarscreamTests/StarscreamTests.swift; sourceTree = "<group>"; };
-		D85927D61ED761A0003460CB /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
-		D85927D71ED76F25003460CB /* include.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = include.h; sourceTree = "<group>"; };
-		D88EAF7E1ED4DFB5004FE2C3 /* Compression.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Compression.swift; path = Sources/Compression.swift; sourceTree = SOURCE_ROOT; };
-		D88EAF811ED4DFD3004FE2C3 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
-		D88EAF831ED4E7D8004FE2C3 /* CompressionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CompressionTests.swift; sourceTree = "<group>"; };
-		D88EAF8D1ED4E92E004FE2C3 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/usr/lib/libz.tbd; sourceTree = DEVELOPER_DIR; };
-		D88EAF901ED4E949004FE2C3 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS10.2.sdk/usr/lib/libz.tbd; sourceTree = DEVELOPER_DIR; };
+		"Cryptor::Cryptor::Product" /* Cryptor.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Cryptor.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		OBJ_10 /* WebSocket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocket.swift; sourceTree = "<group>"; };
+		OBJ_12 /* zlib */ = {isa = PBXFileReference; lastKnownFileType = folder; path = zlib; sourceTree = SOURCE_ROOT; };
+		OBJ_13 /* examples */ = {isa = PBXFileReference; lastKnownFileType = folder; path = examples; sourceTree = SOURCE_ROOT; };
+		OBJ_17 /* Socket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Socket.swift; sourceTree = "<group>"; };
+		OBJ_18 /* SocketProtocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketProtocols.swift; sourceTree = "<group>"; };
+		OBJ_19 /* SocketUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketUtils.swift; sourceTree = "<group>"; };
+		OBJ_20 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = "/Users/caiofbpa/Developer/Starscream/.build/checkouts/BlueSocket-4701229415198575842/Package.swift"; sourceTree = "<group>"; };
+		OBJ_23 /* Crypto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Crypto.swift; sourceTree = "<group>"; };
+		OBJ_24 /* Cryptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cryptor.swift; sourceTree = "<group>"; };
+		OBJ_25 /* Digest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Digest.swift; sourceTree = "<group>"; };
+		OBJ_26 /* HMAC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HMAC.swift; sourceTree = "<group>"; };
+		OBJ_27 /* KeyDerivation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyDerivation.swift; sourceTree = "<group>"; };
+		OBJ_28 /* Random.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Random.swift; sourceTree = "<group>"; };
+		OBJ_29 /* Status.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Status.swift; sourceTree = "<group>"; };
+		OBJ_30 /* StreamCryptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamCryptor.swift; sourceTree = "<group>"; };
+		OBJ_31 /* Updatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Updatable.swift; sourceTree = "<group>"; };
+		OBJ_32 /* Utilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utilities.swift; sourceTree = "<group>"; };
+		OBJ_33 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = "/Users/caiofbpa/Developer/Starscream/.build/checkouts/BlueCryptor--8901950786293101585/Package.swift"; sourceTree = "<group>"; };
+		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
+		OBJ_8 /* Compression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Compression.swift; sourceTree = "<group>"; };
+		OBJ_9 /* SSLSecurity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSLSecurity.swift; sourceTree = "<group>"; };
+		"Socket::Socket::Product" /* Socket.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Socket.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		"Starscream::Starscream::Product" /* Starscream.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Starscream.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		335FA1FB1F5DF71D00F6D2EC /* Frameworks */ = {
+		OBJ_64 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
+			buildActionMask = 0;
 			files = (
-				335FA1FC1F5DF71D00F6D2EC /* libz.tbd in Frameworks */,
+				OBJ_65 /* Socket.framework in Frameworks */,
+				OBJ_66 /* Cryptor.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		33CCF0891F5DDC030099B092 /* Frameworks */ = {
+		OBJ_78 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
+			buildActionMask = 0;
 			files = (
-				33CCF08A1F5DDC030099B092 /* libz.tbd in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_93 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		6B3E79DC19D48B7F006071F7 = {
+		OBJ_11 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				D85927D51ED761A0003460CB /* zlib */,
-				6B3E79E819D48B7F006071F7 /* Sources */,
-				6B3E79FF19D48C2F006071F7 /* Tests */,
-				6B3E79E719D48B7F006071F7 /* Products */,
-				D88EAF801ED4DFD3004FE2C3 /* Frameworks */,
 			);
+			name = Tests;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_14 /* Dependencies */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_15 /* Socket 0.12.86 */,
+				OBJ_21 /* Cryptor 0.8.25 */,
+			);
+			name = Dependencies;
 			sourceTree = "<group>";
 		};
-		6B3E79E719D48B7F006071F7 /* Products */ = {
+		OBJ_15 /* Socket 0.12.86 */ = {
 			isa = PBXGroup;
 			children = (
-				33CCF0921F5DDC030099B092 /* Starscream.framework */,
-				335FA2021F5DF71D00F6D2EC /* Starscream Tests.xctest */,
+				OBJ_16 /* Socket */,
+				OBJ_20 /* Package.swift */,
+			);
+			name = "Socket 0.12.86";
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_16 /* Socket */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_17 /* Socket.swift */,
+				OBJ_18 /* SocketProtocols.swift */,
+				OBJ_19 /* SocketUtils.swift */,
+			);
+			name = Socket;
+			path = ".build/checkouts/BlueSocket-4701229415198575842/Sources/Socket";
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_21 /* Cryptor 0.8.25 */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_22 /* Cryptor */,
+				OBJ_33 /* Package.swift */,
+			);
+			name = "Cryptor 0.8.25";
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_22 /* Cryptor */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_23 /* Crypto.swift */,
+				OBJ_24 /* Cryptor.swift */,
+				OBJ_25 /* Digest.swift */,
+				OBJ_26 /* HMAC.swift */,
+				OBJ_27 /* KeyDerivation.swift */,
+				OBJ_28 /* Random.swift */,
+				OBJ_29 /* Status.swift */,
+				OBJ_30 /* StreamCryptor.swift */,
+				OBJ_31 /* Updatable.swift */,
+				OBJ_32 /* Utilities.swift */,
+			);
+			name = Cryptor;
+			path = ".build/checkouts/BlueCryptor--8901950786293101585/Sources/Cryptor";
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_34 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				"Starscream::Starscream::Product" /* Starscream.framework */,
+				"Socket::Socket::Product" /* Socket.framework */,
+				"Cryptor::Cryptor::Product" /* Cryptor.framework */,
 			);
 			name = Products;
-			sourceTree = "<group>";
+			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		6B3E79E819D48B7F006071F7 /* Sources */ = {
+		OBJ_5 /*  */ = {
 			isa = PBXGroup;
 			children = (
-				5C1360001C473BEF00AA3A01 /* Starscream.h */,
-				5C135FFF1C473BEF00AA3A01 /* SSLSecurity.swift */,
-				5C1360011C473BEF00AA3A01 /* WebSocket.swift */,
-				D88EAF7E1ED4DFB5004FE2C3 /* Compression.swift */,
-				6B3E79E919D48B7F006071F7 /* Supporting Files */,
+				OBJ_6 /* Package.swift */,
+				OBJ_7 /* Sources */,
+				OBJ_11 /* Tests */,
+				OBJ_12 /* zlib */,
+				OBJ_13 /* examples */,
+				OBJ_14 /* Dependencies */,
+				OBJ_34 /* Products */,
+			);
+			name = "";
+			sourceTree = "<group>";
+		};
+		OBJ_7 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_8 /* Compression.swift */,
+				OBJ_9 /* SSLSecurity.swift */,
+				OBJ_10 /* WebSocket.swift */,
 			);
 			path = Sources;
-			sourceTree = "<group>";
-		};
-		6B3E79E919D48B7F006071F7 /* Supporting Files */ = {
-			isa = PBXGroup;
-			children = (
-				5C13600C1C473BFE00AA3A01 /* Info.plist */,
-			);
-			name = "Supporting Files";
-			sourceTree = "<group>";
-		};
-		6B3E79FF19D48C2F006071F7 /* Tests */ = {
-			isa = PBXGroup;
-			children = (
-				6B3E7A0019D48C2F006071F7 /* Info.plist */,
-				742419BB1DC6BDBA003ACE43 /* StarscreamTests.swift */,
-				D88EAF831ED4E7D8004FE2C3 /* CompressionTests.swift */,
-			);
-			path = Tests;
-			sourceTree = "<group>";
-		};
-		D85927D51ED761A0003460CB /* zlib */ = {
-			isa = PBXGroup;
-			children = (
-				D85927D61ED761A0003460CB /* module.modulemap */,
-				D85927D71ED76F25003460CB /* include.h */,
-			);
-			path = zlib;
-			sourceTree = "<group>";
-		};
-		D88EAF801ED4DFD3004FE2C3 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				5CAAB5D01F7987D800F3C556 /* libz.tbd */,
-				D88EAF901ED4E949004FE2C3 /* libz.tbd */,
-				D88EAF8D1ED4E92E004FE2C3 /* libz.tbd */,
-				D88EAF811ED4DFD3004FE2C3 /* libz.tbd */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
+			sourceTree = SOURCE_ROOT;
 		};
 /* End PBXGroup section */
 
-/* Begin PBXHeadersBuildPhase section */
-		33CCF08B1F5DDC030099B092 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				33CCF08C1F5DDC030099B092 /* Starscream.h in Headers */,
-				33CCF08D1F5DDC030099B092 /* include.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXHeadersBuildPhase section */
-
 /* Begin PBXNativeTarget section */
-		335FA1F41F5DF71D00F6D2EC /* Starscream Tests */ = {
+		"Cryptor::Cryptor" /* Cryptor */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 335FA1FF1F5DF71D00F6D2EC /* Build configuration list for PBXNativeTarget "Starscream Tests" */;
+			buildConfigurationList = OBJ_79 /* Build configuration list for PBXNativeTarget "Cryptor" */;
 			buildPhases = (
-				335FA1F51F5DF71D00F6D2EC /* Sources */,
-				335FA1FB1F5DF71D00F6D2EC /* Frameworks */,
-				335FA1FE1F5DF71D00F6D2EC /* Resources */,
+				OBJ_82 /* Sources */,
+				OBJ_93 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 			);
-			name = "Starscream Tests";
-			productName = StarscreamTests;
-			productReference = 335FA2021F5DF71D00F6D2EC /* Starscream Tests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
+			name = Cryptor;
+			productName = Cryptor;
+			productReference = "Cryptor::Cryptor::Product" /* Cryptor.framework */;
+			productType = "com.apple.product-type.framework";
 		};
-		33CCF0841F5DDC030099B092 /* Starscream */ = {
+		"Cryptor::SwiftPMPackageDescription" /* CryptorPackageDescription */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 33CCF08F1F5DDC030099B092 /* Build configuration list for PBXNativeTarget "Starscream" */;
+			buildConfigurationList = OBJ_51 /* Build configuration list for PBXNativeTarget "CryptorPackageDescription" */;
 			buildPhases = (
-				33CCF0851F5DDC030099B092 /* Sources */,
-				33CCF0891F5DDC030099B092 /* Frameworks */,
-				33CCF08B1F5DDC030099B092 /* Headers */,
-				33CCF08E1F5DDC030099B092 /* Resources */,
+				OBJ_54 /* Sources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+			);
+			name = CryptorPackageDescription;
+			productName = CryptorPackageDescription;
+			productType = "com.apple.product-type.framework";
+		};
+		"Socket::Socket" /* Socket */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_71 /* Build configuration list for PBXNativeTarget "Socket" */;
+			buildPhases = (
+				OBJ_74 /* Sources */,
+				OBJ_78 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Socket;
+			productName = Socket;
+			productReference = "Socket::Socket::Product" /* Socket.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		"Socket::SwiftPMPackageDescription" /* SocketPackageDescription */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_45 /* Build configuration list for PBXNativeTarget "SocketPackageDescription" */;
+			buildPhases = (
+				OBJ_48 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SocketPackageDescription;
+			productName = SocketPackageDescription;
+			productType = "com.apple.product-type.framework";
+		};
+		"Starscream::Starscream" /* Starscream */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_57 /* Build configuration list for PBXNativeTarget "Starscream" */;
+			buildPhases = (
+				OBJ_60 /* Sources */,
+				OBJ_64 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				OBJ_67 /* PBXTargetDependency */,
+				OBJ_69 /* PBXTargetDependency */,
 			);
 			name = Starscream;
 			productName = Starscream;
-			productReference = 33CCF0921F5DDC030099B092 /* Starscream.framework */;
+			productReference = "Starscream::Starscream::Product" /* Starscream.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		"Starscream::SwiftPMPackageDescription" /* StarscreamPackageDescription */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_39 /* Build configuration list for PBXNativeTarget "StarscreamPackageDescription" */;
+			buildPhases = (
+				OBJ_42 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = StarscreamPackageDescription;
+			productName = StarscreamPackageDescription;
 			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-		6B3E79DD19D48B7F006071F7 /* Project object */ = {
+		OBJ_1 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftMigration = 0700;
-				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0900;
-				ORGANIZATIONNAME = Vluxe;
-				TargetAttributes = {
-					335FA1F41F5DF71D00F6D2EC = {
-						LastSwiftMigration = 0900;
-					};
-				};
+				LastUpgradeCheck = 9999;
 			};
-			buildConfigurationList = 6B3E79E019D48B7F006071F7 /* Build configuration list for PBXProject "Starscream" */;
+			buildConfigurationList = OBJ_2 /* Build configuration list for PBXProject "Starscream" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
 			);
-			mainGroup = 6B3E79DC19D48B7F006071F7;
-			productRefGroup = 6B3E79E719D48B7F006071F7 /* Products */;
+			mainGroup = OBJ_5 /*  */;
+			productRefGroup = OBJ_34 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				33CCF0841F5DDC030099B092 /* Starscream */,
-				335FA1F41F5DF71D00F6D2EC /* Starscream Tests */,
+				"Starscream::SwiftPMPackageDescription" /* StarscreamPackageDescription */,
+				"Socket::SwiftPMPackageDescription" /* SocketPackageDescription */,
+				"Cryptor::SwiftPMPackageDescription" /* CryptorPackageDescription */,
+				"Starscream::Starscream" /* Starscream */,
+				"Socket::Socket" /* Socket */,
+				"Cryptor::Cryptor" /* Cryptor */,
+				"CommonCrypto::CommonCrypto::ProductTarget" /* CommonCrypto */,
 			);
 		};
 /* End PBXProject section */
 
-/* Begin PBXResourcesBuildPhase section */
-		335FA1FE1F5DF71D00F6D2EC /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		33CCF08E1F5DDC030099B092 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXResourcesBuildPhase section */
-
 /* Begin PBXSourcesBuildPhase section */
-		335FA1F51F5DF71D00F6D2EC /* Sources */ = {
+		OBJ_42 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
+			buildActionMask = 0;
 			files = (
-				335FA1F61F5DF71D00F6D2EC /* Compression.swift in Sources */,
-				335FA1F71F5DF71D00F6D2EC /* SSLSecurity.swift in Sources */,
-				335FA1F81F5DF71D00F6D2EC /* WebSocket.swift in Sources */,
-				335FA1F91F5DF71D00F6D2EC /* CompressionTests.swift in Sources */,
-				335FA1FA1F5DF71D00F6D2EC /* StarscreamTests.swift in Sources */,
+				OBJ_43 /* Package.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		33CCF0851F5DDC030099B092 /* Sources */ = {
+		OBJ_48 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
+			buildActionMask = 0;
 			files = (
-				33CCF0861F5DDC030099B092 /* Compression.swift in Sources */,
-				33CCF0871F5DDC030099B092 /* WebSocket.swift in Sources */,
-				33CCF0881F5DDC030099B092 /* SSLSecurity.swift in Sources */,
+				OBJ_49 /* Package.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_54 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_55 /* Package.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_60 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_61 /* Compression.swift in Sources */,
+				OBJ_62 /* SSLSecurity.swift in Sources */,
+				OBJ_63 /* WebSocket.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_74 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_75 /* Socket.swift in Sources */,
+				OBJ_76 /* SocketProtocols.swift in Sources */,
+				OBJ_77 /* SocketUtils.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_82 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_83 /* Crypto.swift in Sources */,
+				OBJ_84 /* Cryptor.swift in Sources */,
+				OBJ_85 /* Digest.swift in Sources */,
+				OBJ_86 /* HMAC.swift in Sources */,
+				OBJ_87 /* KeyDerivation.swift in Sources */,
+				OBJ_88 /* Random.swift in Sources */,
+				OBJ_89 /* Status.swift in Sources */,
+				OBJ_90 /* StreamCryptor.swift in Sources */,
+				OBJ_91 /* Updatable.swift in Sources */,
+				OBJ_92 /* Utilities.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		OBJ_67 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "Socket::Socket" /* Socket */;
+			targetProxy = B4A3C2762019D718003EC7DF /* PBXContainerItemProxy */;
+		};
+		OBJ_69 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "Cryptor::Cryptor" /* Cryptor */;
+			targetProxy = B4A3C2772019D718003EC7DF /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin XCBuildConfiguration section */
-		335FA2001F5DF71D00F6D2EC /* Debug */ = {
+		OBJ_3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = NO;
-				CLANG_ENABLE_MODULES = YES;
-				DEVELOPMENT_TEAM = "";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				INFOPLIST_FILE = "$(SRCROOT)/Tests/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks @executable_path/../Frameworks @loader_path/../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.vluxe.$(PRODUCT_NAME:rfc1034identifier)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = "";
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvos appletvsimulator macosx";
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.0;
-			};
-			name = Debug;
-		};
-		335FA2011F5DF71D00F6D2EC /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = NO;
-				CLANG_ENABLE_MODULES = YES;
-				DEVELOPMENT_TEAM = "";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
-				INFOPLIST_FILE = "$(SRCROOT)/Tests/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks @executable_path/../Frameworks @loader_path/../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.vluxe.$(PRODUCT_NAME:rfc1034identifier)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = "";
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvos appletvsimulator macosx";
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.0;
-			};
-			name = Release;
-		};
-		33CCF0901F5DDC030099B092 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BITCODE_GENERATION_MODE = marker;
-				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "Mac Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = "";
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "$(SRCROOT)/Sources/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				OTHER_LDFLAGS = "";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.vluxe.$(PRODUCT_NAME:rfc1034identifier)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "";
-				SDKROOT = "";
-				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx appletvsimulator appletvos watchos watchsimulator";
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.0;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
-				VALID_ARCHS = "x86_64 i386 arm64 armv7s armv7 armv7k";
-				WATCHOS_DEPLOYMENT_TARGET = 2.0;
-			};
-			name = Debug;
-		};
-		33CCF0911F5DDC030099B092 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BITCODE_GENERATION_MODE = bitcode;
-				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = "";
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "$(SRCROOT)/Sources/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
-				OTHER_LDFLAGS = "";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.vluxe.$(PRODUCT_NAME:rfc1034identifier)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE = "";
-				SDKROOT = "";
-				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx appletvsimulator appletvos watchos watchsimulator";
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.0;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
-				VALID_ARCHS = "x86_64 i386 arm64 armv7s armv7 armv7k";
-				WATCHOS_DEPLOYMENT_TARGET = 2.0;
-			};
-			name = Release;
-		};
-		6B3E79F719D48B7F006071F7 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				APPLICATION_EXTENSION_API_ONLY = YES;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 1;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_TESTABILITY = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_NO_COMMON_BLOCKS = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MTL_ENABLE_DEBUG_INFO = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				ONLY_ACTIVE_ARCH = YES;
-				SDKROOT = "";
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx appletvos appletvsimulator watchsimulator watchos";
-				SWIFT_INCLUDE_PATHS = $SRCROOT/zlib;
+				OTHER_SWIFT_FLAGS = "-DXcode";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2,3,4";
-				VALID_ARCHS = "x86_64 i386";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
+				USE_HEADERMAP = NO;
 			};
 			name = Debug;
 		};
-		6B3E79F819D48B7F006071F7 /* Release */ = {
+		OBJ_4 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				APPLICATION_EXTENSION_API_ONLY = YES;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				ENABLE_NS_ASSERTIONS = NO;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				SDKROOT = "";
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx appletvos appletvsimulator watchsimulator watchos";
-				SWIFT_INCLUDE_PATHS = $SRCROOT/zlib;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_OPTIMIZATION_LEVEL = s;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_SWIFT_FLAGS = "-DXcode";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		OBJ_40 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 3 -I /Library/Developer/Toolchains/swift-4.0-RELEASE.xctoolchain/usr/lib/swift/pm/3 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk";
+				SWIFT_VERSION = 3.0;
+			};
+			name = Debug;
+		};
+		OBJ_41 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 3 -I /Library/Developer/Toolchains/swift-4.0-RELEASE.xctoolchain/usr/lib/swift/pm/3 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk";
+				SWIFT_VERSION = 3.0;
+			};
+			name = Release;
+		};
+		OBJ_46 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 4 -I /Library/Developer/Toolchains/swift-4.0-RELEASE.xctoolchain/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk";
 				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2,3,4";
-				VALIDATE_PRODUCT = YES;
-				VALID_ARCHS = "x86_64 i386";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		OBJ_47 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 4 -I /Library/Developer/Toolchains/swift-4.0-RELEASE.xctoolchain/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk";
+				SWIFT_VERSION = 4.0;
+			};
+			name = Release;
+		};
+		OBJ_52 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 4 -I /Library/Developer/Toolchains/swift-4.0-RELEASE.xctoolchain/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk";
+				SWIFT_VERSION = 4.0;
+			};
+			name = Debug;
+		};
+		OBJ_53 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 4 -I /Library/Developer/Toolchains/swift-4.0-RELEASE.xctoolchain/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk";
+				SWIFT_VERSION = 4.0;
+			};
+			name = Release;
+		};
+		OBJ_58 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/.build/checkouts/CommonCrypto.git-1219305460334093717",
+					"$(SRCROOT)/.build/checkouts/common-crypto-spm--132958532151328779",
+					"$(SRCROOT)/.build/checkouts/zlib-spm.git-7042465659040932026",
+				);
+				INFOPLIST_FILE = Starscream.xcodeproj/Starscream_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = Starscream;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
+				TARGET_NAME = Starscream;
+			};
+			name = Debug;
+		};
+		OBJ_59 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/.build/checkouts/CommonCrypto.git-1219305460334093717",
+					"$(SRCROOT)/.build/checkouts/common-crypto-spm--132958532151328779",
+					"$(SRCROOT)/.build/checkouts/zlib-spm.git-7042465659040932026",
+				);
+				INFOPLIST_FILE = Starscream.xcodeproj/Starscream_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = Starscream;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
+				TARGET_NAME = Starscream;
+			};
+			name = Release;
+		};
+		OBJ_72 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = Starscream.xcodeproj/Socket_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = Socket;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+				TARGET_NAME = Socket;
+			};
+			name = Debug;
+		};
+		OBJ_73 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = Starscream.xcodeproj/Socket_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = Socket;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+				TARGET_NAME = Socket;
+			};
+			name = Release;
+		};
+		OBJ_80 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/.build/checkouts/CommonCrypto.git-1219305460334093717",
+				);
+				INFOPLIST_FILE = Starscream.xcodeproj/Cryptor_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = Cryptor;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+				TARGET_NAME = Cryptor;
+			};
+			name = Debug;
+		};
+		OBJ_81 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/.build/checkouts/CommonCrypto.git-1219305460334093717",
+				);
+				INFOPLIST_FILE = Starscream.xcodeproj/Cryptor_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = Cryptor;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+				TARGET_NAME = Cryptor;
+			};
+			name = Release;
+		};
+		OBJ_96 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		OBJ_97 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
 			};
 			name = Release;
 		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		335FA1FF1F5DF71D00F6D2EC /* Build configuration list for PBXNativeTarget "Starscream Tests" */ = {
+		OBJ_2 /* Build configuration list for PBXProject "Starscream" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				335FA2001F5DF71D00F6D2EC /* Debug */,
-				335FA2011F5DF71D00F6D2EC /* Release */,
+				OBJ_3 /* Debug */,
+				OBJ_4 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Debug;
 		};
-		33CCF08F1F5DDC030099B092 /* Build configuration list for PBXNativeTarget "Starscream" */ = {
+		OBJ_39 /* Build configuration list for PBXNativeTarget "StarscreamPackageDescription" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				33CCF0901F5DDC030099B092 /* Debug */,
-				33CCF0911F5DDC030099B092 /* Release */,
+				OBJ_40 /* Debug */,
+				OBJ_41 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Debug;
 		};
-		6B3E79E019D48B7F006071F7 /* Build configuration list for PBXProject "Starscream" */ = {
+		OBJ_45 /* Build configuration list for PBXNativeTarget "SocketPackageDescription" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				6B3E79F719D48B7F006071F7 /* Debug */,
-				6B3E79F819D48B7F006071F7 /* Release */,
+				OBJ_46 /* Debug */,
+				OBJ_47 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Debug;
+		};
+		OBJ_51 /* Build configuration list for PBXNativeTarget "CryptorPackageDescription" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_52 /* Debug */,
+				OBJ_53 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		OBJ_57 /* Build configuration list for PBXNativeTarget "Starscream" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_58 /* Debug */,
+				OBJ_59 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		OBJ_71 /* Build configuration list for PBXNativeTarget "Socket" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_72 /* Debug */,
+				OBJ_73 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		OBJ_79 /* Build configuration list for PBXNativeTarget "Cryptor" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_80 /* Debug */,
+				OBJ_81 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		OBJ_95 /* Build configuration list for PBXAggregateTarget "CommonCrypto" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_96 /* Debug */,
+				OBJ_97 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
 		};
 /* End XCConfigurationList section */
 	};
-	rootObject = 6B3E79DD19D48B7F006071F7 /* Project object */;
+	rootObject = OBJ_1 /* Project object */;
 }


### PR DESCRIPTION
Related to #346 

This should work on macOS, iOS and Linux. I couldn't manage to run Autobahn|Testsuite on it, though. Can someone help? Also I'm not sure how to test on other platforms like tvOS and watchOS.

I'm not sure replacing SSCommonCrypto (like I did) is the best approach. Would you rather have a `#if os(Linux)` around the Cryptor usage, keeping the old code on the `#else`? Or maybe go for something a little more fancy like what was done in `WSStream` to allow polymorphism? This polymorphic route is a bit bumpy because it could mean dynamic dependencies on `Package.json` and `Cartfile` or coming up with a plugin mechanism involving multiple repos.

I personally like the idea of just using IBM's cross-platform libraries "everywhere" as the base while the Server Work Group (or Apple itself) doesn't come up with an official solution. For that we would have to make sure IBM's BlueCryptor (and later on BlueSocket) work on all targeted platforms.

I tried to add BlueCryptor to Cartfile, but apparently BlueCryptor does not support Carthage. Is that an impediment to using it in Starscream?