### PR TITLE
Remove Cartfile as the checkout is unused

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,0 @@
-github "daltoniam/zlib-spm" ~> 1.1
-github "daltoniam/common-crypto-spm" ~> 1.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,0 @@
-github "daltoniam/zlib-spm" "1.1"
-github "daltoniam/common-crypto-spm" "1.1"


### PR DESCRIPTION
The artifacts are unused. The modulemap in `zlib/` is used by the Starscream framework.

See the [`no-carthage-deps-fork` branch](https://github.com/rastersize/StarscreamViaCarthage/tree/no-carthage-deps-fork) of my StarscreamViaCarthage demo project for verification that it still works as intended 🙂

See the discussion in #445 for further details.