### PR TITLE
Fix crash caused by cleanup() being called from multiple threads

### DIFF
--- a/Sources/WebSocket.swift
+++ b/Sources/WebSocket.swift
@@ -139,6 +139,8 @@ open class FoundationStream : NSObject, WSStream, StreamDelegate  {
     private var outputStream: OutputStream?
     public weak var delegate: WSStreamDelegate?
     let BUFFER_MAX = 4096
+    
+    private let cleanupMutex = NSLock()
 	
 	public var enableSOCKSProxy = false
     
@@ -248,6 +250,8 @@ open class FoundationStream : NSObject, WSStream, StreamDelegate  {
     }
     
     public func cleanup() {
+        cleanupMutex.lock()
+        
         if let stream = inputStream {
             stream.delegate = nil
             CFReadStreamSetDispatchQueue(stream, nil)
@@ -260,6 +264,8 @@ open class FoundationStream : NSObject, WSStream, StreamDelegate  {
         }
         outputStream = nil
         inputStream = nil
+        
+        cleanupMutex.unlock()
     }
     
     #if os(Linux) || os(watchOS)


### PR DESCRIPTION
If InputStream/OutputStream .close() or *SetDispatchQueue is called
from two threads at the same time, it will cause a crash. This adds a
lock to prevent the cleanup() method from executing concurrently. Once
the first one is complete, inputStream and outputStream and nil and so
simultaneous attempts to cleanup() become noops.

Is it possible that locking inside cleanup() has some unintended side-effects? Take a look at let me know. I am not as familiar with the codebase...