### PR TITLE
added open keyword to SSLSecurity.isValid, added public to other methods

### DIFF
--- a/Sources/SSLSecurity.swift
+++ b/Sources/SSLSecurity.swift
@@ -198,7 +198,7 @@ open class SSLSecurity : SSLTrustValidator {
     
     - returns: a public key
     */
-    func extractPublicKey(_ data: Data) -> SecKey? {
+    public func extractPublicKey(_ data: Data) -> SecKey? {
         guard let cert = SecCertificateCreateWithData(nil, data as CFData) else { return nil }
         
         return extractPublicKey(cert, policy: SecPolicyCreateBasicX509())
@@ -211,7 +211,7 @@ open class SSLSecurity : SSLTrustValidator {
     
     - returns: a public key
     */
-    func extractPublicKey(_ cert: SecCertificate, policy: SecPolicy) -> SecKey? {
+    public func extractPublicKey(_ cert: SecCertificate, policy: SecPolicy) -> SecKey? {
         var possibleTrust: SecTrust?
         SecTrustCreateWithCertificates(cert, policy, &possibleTrust)
         
@@ -228,7 +228,7 @@ open class SSLSecurity : SSLTrustValidator {
     
     - returns: the certificate chain for the trust
     */
-    func certificateChain(_ trust: SecTrust) -> [Data] {
+    public func certificateChain(_ trust: SecTrust) -> [Data] {
         let certificates = (0..<SecTrustGetCertificateCount(trust)).reduce([Data]()) { (certificates: [Data], index: Int) -> [Data] in
             var certificates = certificates
             let cert = SecTrustGetCertificateAtIndex(trust, index)
@@ -246,7 +246,7 @@ open class SSLSecurity : SSLTrustValidator {
     
     - returns: the public keys from the certifcate chain for the trust
     */
-    func publicKeyChain(_ trust: SecTrust) -> [SecKey] {
+    public func publicKeyChain(_ trust: SecTrust) -> [SecKey] {
         let policy = SecPolicyCreateBasicX509()
         let keys = (0..<SecTrustGetCertificateCount(trust)).reduce([SecKey]()) { (keys: [SecKey], index: Int) -> [SecKey] in
             var keys = keys

--- a/Sources/SSLSecurity.swift
+++ b/Sources/SSLSecurity.swift
@@ -133,7 +133,7 @@ open class SSLSecurity : SSLTrustValidator {
     
     - returns: if the key was successfully validated
     */
-    public func isValid(_ trust: SecTrust, domain: String?) -> Bool {
+    open func isValid(_ trust: SecTrust, domain: String?) -> Bool {
         
         var tries = 0
         while !self.isReady {


### PR DESCRIPTION
After connecting (or failing to connect), I need to be able to access the raw SSL certs. 

The correct-ist solution is probably some delegate methods, but making SSLSecurity.isValid() an open function is a much simpler solution-- I can override isValid() and directly access _trust_ and _domain_.