### PR TITLE
Always wait for currently executing operations to finish

### DIFF
--- a/Sources/WebSocket.swift
+++ b/Sources/WebSocket.swift
@@ -710,11 +710,11 @@ open class WebSocket : NSObject, StreamDelegate, WebSocketClient, WSStreamDelega
      Disconnect the stream object and notifies the delegate.
      */
     private func disconnectStream(_ error: Error?, runDelegate: Bool = true) {
-        if error == nil {
-            writeQueue.waitUntilAllOperationsAreFinished()
-        } else {
+        if error != nil {
             writeQueue.cancelAllOperations()
         }
+
+        writeQueue.waitUntilAllOperationsAreFinished()
         
         mutex.lock()
         cleanupStream()


### PR DESCRIPTION
I am seeing a number of crashes caused by a nil `outputStream` in sslTrust(), **release 3.0.5**.
 I can confirm that the issue is a nil output stream because the crashes are randomly occurring on lines 266, 267, and 269 in WebSocket.swift which are all attempting to access/force unwrap `outputStream`. Thus, the issue most likely is an async issue where `outputStream` is getting set to nil at different times.

This PR attempts to fix the issue by waiting until currently executing operations have completed before we set `outputStream` to nil, and avoid another concurrentOperation from accessing a nil `outputStream`.


**Per the documentation on `cancelAllOperations`:** https://developer.apple.com/documentation/foundation/nsoperationqueue/1417849-cancelalloperations 

"Canceling the operations does not automatically remove them from the queue or stop those that are currently executing. For operations that are queued and waiting execution, the queue must still attempt to execute the operation before recognizing that it is canceled and moving it to the finished state. For operations that are already executing, the operation object itself must check for cancellation and stop what it is doing so that it can move to the finished state. In both cases, a finished (or canceled) operation is still given a chance to execute its completion block before it is removed from the queue."