### PR TITLE
Fix crash nil outstream

### DIFF
--- a/Sources/WebSocket.swift
+++ b/Sources/WebSocket.swift
@@ -263,8 +263,10 @@ open class FoundationStream : NSObject, WSStream, StreamDelegate  {
     #if os(Linux) || os(watchOS)
     #else
     public func sslTrust() -> (trust: SecTrust?, domain: String?) {
-        let trust = outputStream!.property(forKey: kCFStreamPropertySSLPeerTrust as Stream.PropertyKey) as! SecTrust?
-        var domain = outputStream!.property(forKey: kCFStreamSSLPeerName as Stream.PropertyKey) as? String
+        guard let outputStream = outputStream else { return (nil, nil) }
+
+        let trust = outputStream.property(forKey: kCFStreamPropertySSLPeerTrust as Stream.PropertyKey) as! SecTrust?
+        var domain = outputStream.property(forKey: kCFStreamSSLPeerName as Stream.PropertyKey) as! String?
         if domain == nil,
             let sslContextOut = CFWriteStreamCopyProperty(outputStream, CFStreamPropertyKey(rawValue: kCFStreamPropertySSLContext)) as! SSLContext? {
             var peerNameLen: Int = 0

--- a/Tests/CompressionTests.swift
+++ b/Tests/CompressionTests.swift
@@ -52,8 +52,9 @@ class CompressionTests: XCTestCase {
         // 2 Gigs!
 //        var rawData = Data(repeating: 0, count: 0x80000000)
         var rawData = Data(repeating: 0, count: 0x80000)
+        let rawDataLen = rawData.count
         rawData.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) -> Void in
-            arc4random_buf(ptr, rawData.count)
+            arc4random_buf(ptr, rawDataLen)
         }
         
         let compressed = try! compressor.compress(rawData)


### PR DESCRIPTION
Expected to fix #523 

Looks like there is a code path in which websocket.sslTrust() may be called when outputStream is `nil`. The cast to create `domain` is unsafe, because `nil as! String` *may crash*, while `nil as! String?` will never crash.

Using an optional `String?` here is perfectly fine because a `String` would be cast to `String?` anyway when returned in the tuple `(SecTrust?, String?)`.

I have also added a guard at the top which itself will *probably* fix the issue. IMO having both safeguards in place is the best practice. The`outputStream` *should* not be nil for this function to produce anything useful (hence the guard). While it is technically still possible for `kCFStreamSSLPeerName` to be nil, although it should not be.