### PR TITLE
Documents `disconnect` behavior in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,12 @@ The disconnect method does what you would expect and closes the socket.
 socket.disconnect()
 ```
 
+The socket can be forcefully closed, by specifying a timeout (in milliseconds). A timeout of zero will also close the socket immediately without waiting on the server.
+
+```swift
+socket.disconnect(forceTimeout: 10, closeCode: CloseCode.normal.rawValue)
+```
+
 ### isConnected
 
 Returns if the socket is connected or not.


### PR DESCRIPTION
I was confused by some behavior in `disconnect` that is only documented within the code. I've just added this information to the README to help others.

See #526.