### PR TITLE
Expose path viability and better path updates

### DIFF
--- a/Sources/Starscream/NetworkStream.swift
+++ b/Sources/Starscream/NetworkStream.swift
@@ -28,7 +28,7 @@ import Network
 /// it will continue to be provided for backwards compatibility reasons.
 @available(iOSApplicationExtension 12.0, tvOSApplicationExtension 12.0, OSXApplicationExtension 10.14, *)
 open class NetworkStream: WSStream {
-    public var delegate: WSStreamDelegate?
+    public weak var delegate: WSStreamDelegate?
     private var stream: NWConnection?
     private static let sharedWorkQueue = DispatchQueue(label: "com.vluxe.starscream.networkstream", attributes: [])
     private var readQueue = [Data]()

--- a/Sources/Starscream/NetworkStream.swift
+++ b/Sources/Starscream/NetworkStream.swift
@@ -75,7 +75,7 @@ open class NetworkStream: WSStream {
         }
 
         conn.betterPathUpdateHandler = { [weak self] (isBetter) in
-            self?.delegate?.streamBetterPathUpdate(isBetter: false)
+            self?.delegate?.streamBetterPathUpdate(isBetter: isBetter)
         }
 
         conn.start(queue: NetworkStream.sharedWorkQueue)


### PR DESCRIPTION
Proposal for exposing better path updates and path viability.
I'm not sure if the framework should handle migration. Maybe it's better let the user to do the switching if opening an other web socket needs some additional non-generic work done before it's good.

See #565

Good info was provided in WWDC2018 https://developer.apple.com/videos/play/wwdc2018/715/