### PR TITLE
Wrap Network import with `canImport`

### DIFF
--- a/Sources/Starscream/NetworkStream.swift
+++ b/Sources/Starscream/NetworkStream.swift
@@ -21,7 +21,9 @@
 //////////////////////////////////////////////////////////////////////////////////////////////////
 
 import Foundation
+#if canImport(Network)
 import Network
+#endif
 
 /// Implementation of the Network framework that was introduced in iOS 12/MacOS 10.14.
 /// This class will probably replace the Foundation one in the future, but because Foundation is battle-tested


### PR DESCRIPTION
Carthage fails to build branch xcode-10 due to Network framework not being available.

Carthage/Checkouts/Starscream/Sources/Starscream/NetworkStream.swift:24:8: error: no such module 'Network'