### PR TITLE
Don't add empty Sec-WebSocket-Protocol header

### DIFF
--- a/Sources/Starscream/WebSocket.swift
+++ b/Sources/Starscream/WebSocket.swift
@@ -475,7 +475,7 @@ open class WebSocket : NSObject, StreamDelegate, WebSocketClient, WSStreamDelega
             }
             self.request.setValue(origin, forHTTPHeaderField: headerOriginName)
         }
-        if let protocols = protocols {
+        if let protocols = protocols, !protocols.isEmpty {
             self.request.setValue(protocols.joined(separator: ","), forHTTPHeaderField: headerWSProtocolName)
         }
         writeQueue.maxConcurrentOperationCount = 1


### PR DESCRIPTION
> The request MAY include a header field with the name
> |Sec-WebSocket-Protocol|.  If present, this value indicates one
> or more comma-separated subprotocol the client wishes to speak,
> ordered by preference.
> 
> -- The WebSocket Protocol (https://tools.ietf.org/html/rfc6455)

Passing an empty / neutral array should be the same as passing `nil` here.
The WebSocket API (in Browsers) also seems to treat `null` and `[]` the same.

Preferably the initializer signature should be `protocols: [String] = []`,
but that would make this a breaking change.