### PR TITLE
Fix Xcode 10.1 valid archs warnings

### DIFF
--- a/Starscream.xcodeproj/project.pbxproj
+++ b/Starscream.xcodeproj/project.pbxproj
@@ -314,7 +314,6 @@
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 4.0;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
-				VALID_ARCHS = "x86_64 i386 arm64 armv7s armv7 armv7k";
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Debug;
@@ -343,7 +342,6 @@
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 4.0;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
-				VALID_ARCHS = "x86_64 i386 arm64 armv7s armv7 armv7k";
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Release;
@@ -401,7 +399,11 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
-				VALID_ARCHS = "x86_64 i386";
+				VALID_ARCHS = "arm64 armv7s armv7 armv7k";
+				"VALID_ARCHS[sdk=appletvsimulator*]" = "x86_64 i386";
+				"VALID_ARCHS[sdk=iphonesimulator*]" = "x86_64 i386";
+				"VALID_ARCHS[sdk=macosx*]" = "x86_64 i386";
+				"VALID_ARCHS[sdk=watchsimulator*]" = "x86_64 i386";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -452,7 +454,11 @@
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
 				VALIDATE_PRODUCT = YES;
-				VALID_ARCHS = "x86_64 i386";
+				VALID_ARCHS = "arm64 armv7s armv7 armv7k";
+				"VALID_ARCHS[sdk=appletvos*]" = "x86_64 i386";
+				"VALID_ARCHS[sdk=iphonesimulator*]" = "x86_64 i386";
+				"VALID_ARCHS[sdk=macosx*]" = "x86_64 i386";
+				"VALID_ARCHS[sdk=watchsimulator*]" = "x86_64 i386";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};


### PR DESCRIPTION
Xcode 10.1 is complaining that it can't find a valid architecture when building for simulators:
```
warning: Mapping architecture arm64 to x86_64. Ensure that this target's Architectures and Valid Architectures build settings are configured correctly for the iOS Simulator platform. (in target 'Starscream')
```
This PR fixes all simulators (TvOS, macOS, watchOS, iPhoneOS).