### PR TITLE
Fix FrozenError in ws-server.rb

### DIFF
--- a/examples/SimpleTest/ws-server.rb
+++ b/examples/SimpleTest/ws-server.rb
@@ -19,7 +19,7 @@ EM.run {
 
     ws.onmessage { |msg|
       puts "message from client: #{msg}"
-      ws.send Faker::Hacker.say_something_smart
+      ws.send +Faker::Hacker.say_something_smart
     }
   end
 }


### PR DESCRIPTION
Launching examples/SimpleTest/ws-server.rb and tap 'Write Text' on the test iPhone app, following log are printed by ws-server.rb and the connection is closed with an error:

```
$ ruby ws-server.rb 
WebSocket connection open
origin: http://localhost:8080
headers: {"Host"=>"localhost:8080", "Sec-WebSocket-Version"=>"13", "Sec-WebSocket-Extensions"=>"permessage-deflate; client_max_window_bits; server_max_window_bits=15", "Origin"=>"http://localhost:8080", "Connection"=>"Upgrade", "Sec-WebSocket-Key"=>"cnhidXdpaW9wYnlpc2htcw==", "Upgrade"=>"websocket"}
message from client: hello there!
[error] can't modify frozen String
Connection closed
```

By commenting out the error handler, I got details:

```
$ ruby ws-server.rb 
WebSocket connection open
origin: http://localhost:8080
headers: {"Connection"=>"Upgrade", "Upgrade"=>"websocket", "Host"=>"localhost:8080", "Origin"=>"http://localhost:8080", "Sec-WebSocket-Key"=>"bGZ3cWJ0b3dzYmVycnNwcA==", "Sec-WebSocket-Version"=>"13", "Sec-WebSocket-Extensions"=>"permessage-deflate; client_max_window_bits; server_max_window_bits=15"}
message from client: hello there!
Connection closed
Traceback (most recent call last):
	10: from ws-server.rb:4:in `<main>'
	 9: from /Users/ohara/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/eventmachine-1.2.7/lib/eventmachine.rb:195:in `run'
	 8: from /Users/ohara/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/eventmachine-1.2.7/lib/eventmachine.rb:195:in `run_machine'
	 7: from /Users/ohara/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/em-websocket-0.5.1/lib/em-websocket/connection.rb:76:in `receive_data'
	 6: from /Users/ohara/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/em-websocket-0.5.1/lib/em-websocket/handler.rb:47:in `receive_data'
	 5: from /Users/ohara/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/em-websocket-0.5.1/lib/em-websocket/framing07.rb:118:in `process_data'
	 4: from /Users/ohara/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/em-websocket-0.5.1/lib/em-websocket/message_processor_06.rb:52:in `message'
	 3: from /Users/ohara/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/em-websocket-0.5.1/lib/em-websocket/connection.rb:18:in `trigger_on_message'
	 2: from ws-server.rb:22:in `block (3 levels) in <main>'
	 1: from /Users/ohara/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/em-websocket-0.5.1/lib/em-websocket/connection.rb:161:in `send_text'
/Users/ohara/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/em-websocket-0.5.1/lib/em-websocket/connection.rb:161:in `force_encoding': can't modify frozen String (FrozenError)
```

The reason of this is trying to modify an immutable string.
This PR resolve this issue by making a mutable copy of the immutable string.