### PR TITLE
Fix data race issue.

### DIFF
--- a/Sources/Starscream/WebSocket.swift
+++ b/Sources/Starscream/WebSocket.swift
@@ -778,7 +778,7 @@ open class WebSocket : NSObject, StreamDelegate, WebSocketClient, WSStreamDelega
                 }
                 let buffer = UnsafeRawPointer((work as NSData).bytes).assumingMemoryBound(to: UInt8.self)
                 let length = work.count
-                if !connected {
+                if !isConnected {
                     processTCPHandshake(buffer, bufferLen: length)
                 } else {
                     processRawMessagesInBuffer(buffer, bufferLen: length)


### PR DESCRIPTION
```
WARNING: ThreadSanitizer: data race (pid=45377)
  Write of size 1 at 0x7b5800003218 by thread T1 (mutexes: write M2680):
    #0 $s10Starscream9WebSocketC9connected33_E91840E7069A0D2D302D042308E9D928LLSbvs <null> (Starscream:x86_64+0x2c369)
    #1 $s10Starscream9WebSocketC12doDisconnect33_E91840E7069A0D2D302D042308E9D928LLyys5Error_pSgF <null> (Starscream:x86_64+0x56e2c)
    #2 $s10Starscream9WebSocketC12dequeueWrite33_E91840E7069A0D2D302D042308E9D928LL_4code15writeCompletiony10Foundation4DataV_AC6OpCodeOyycSgtFyycfU_ <null> (Starscream:x86_64+0x55f2e)
    #3 $s10Starscream9WebSocketC12dequeueWrite33_E91840E7069A0D2D302D042308E9D928LL_4code15writeCompletiony10Foundation4DataV_AC6OpCodeOyycSgtFyycfU_TA <null> (Starscream:x86_64+0x63d85)
    #4 $sIeg_IeyB_TR <null> (Starscream:x86_64+0x13d70)
    #5 __NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__ <null> (Foundation:x86_64+0x95411)
Total pre-main time:  19.61 mill    #6 _dispatch_client_callout <null> (libdispatch.dylib:x86_64+0x3db4)
iseconds (100.0%)

         dylib loading time:  10  Previous read of size 1 at 0x7b5800003218 by thread T3.72 milliseconds (54.6%)
:
        rebase/binding time:   3.61 milliseconds (18.4%)
    #0 $s10Starscream9WebSocketC9connected33_E91840E7069A0D2D302D042308E9D928LLSbvg <null> (Starscream:x86_64+0x2c27e)
            ObjC setup time:   2.82 milliseconds (14.4%)
           initializer time:   2.36 milliseconds (12.0%)
           slowest intializers :
             libSystem.B.dylib     #1 $s10Starscream9WebSocketC12dequeueInput33_E91840E7069A0D2D302D042308E9D928LLyyFyyXEfU_ <null> (Starscream:x86_64+0x3a9f9)
:   0.85 milliseconds (4.3%)
                CoreFoundation     #2 $s10Starscream9WebSocketC12dequeueInput33_E91840E7069A0D2D302D042308E9D928LLyyFyyXEfU_TA <null> (Starscream:x86_64+0x62331)
    #3 $ss5Error_pIgzo_ytsAA_pIegrzo_TR <null> (Starscream:x86_64+0x3b106)
    #4 $ss5Error_pIgzo_ytsAA_pIegrzo_TRTA <null> (Starscream:x86_64+0x623de)
    #5 $s10ObjectiveC15autoreleasepool8invokingxxyKXE_tKlF <null> (libswiftObjectiveC.dylib:x86_64+0x2dde)
    #6 $s10Starscream9WebSocketC18processInputStream33_E91840E7069A0D2D302D042308E9D928LLyyF <null> (Starscream:x86_64+0x3a21e)
    #7 $s10Starscream9WebSocketC16newBytesInStreamyyF <null> (Starscream:x86_64+0x39afc)
    #8 $s10Starscream9WebSocketCAA16WSStreamDelegateA2aDP16newBytesInStreamyyFTW <null> (Starscream:x86_64+0x5939f)
    #9 $s10Starscream16FoundationStreamC6stream_6handleySo8NSStreamC_So0F5EventVtF <null> (Starscream:x86_64+0x234fe)
:   0.91 milliseconds (4.6%)
                    Foundation :   0.84 milliseconds (4.2%)

    #10 $s10Starscream16FoundationStreamC6stream_6handleySo8NSStreamC_So0F5EventVtFTo <null> (Starscream:x86_64+0x23c85)
    #11 _signalEventSync <null> (CoreFoundation:x86_64+0xa0ab3)
    #12 _dispatch_client_callout <null> (libdispatch.dylib:x86_64+0x3db4)

  Location is heap block of size 664 at 0x7b5800003000 allocated by main thread:
    #0 calloc <null> (libclang_rt.tsan_iossim_dynamic.dylib:x86_64+0x4a6b2)
    #1 class_createInstance <null> (libobjc.A.dylib:x86_64+0xf34f)
    #2 $s10Starscream9WebSocketC3url9protocolsAC10Foundation3URLV_SaySSGSgtcfC <null> (Starscream:x86_64+0x31c43)
    #3 $s12 MyAPP8QZEngineC4openyyF <null> ( MyAPP:x86_64+0x100a414e9)
    #4 $s12 MyAPP8QZEngineC4typeAcA0C4TypeO_tc33_9DA9368FB478760390B65F344D9F1BEFLlfc <null> ( MyAPP:x86_64+0x100a3fde2)
    #5 $s12 MyAPP8QZEngineC4typeAcA0C4TypeO_tc33_9DA9368FB478760390B65F344D9F1BEFLlfC <null> ( MyAPP:x86_64+0x100a3eec6)
    #6 $s12 MyAPP8QZEngineC4mainACvpZfiACyXEfU_ <null> ( MyAPP:x86_64+0x100a420a7)
    #7 globalinit_33_9DA9368FB478760390B65F344D9F1BEF_func2 <null> ( MyAPP:x86_64+0x100a42035)
    #8 dispatch_once <null> (libclang_rt.tsan_iossim_dynamic.dylib:x86_64+0x682d4)
    #9 dispatch_once_f <null> (libclang_rt.tsan_iossim_dynamic.dylib:x86_64+0x683c0)
    #10 swift_once <null> (libswiftCore.dylib:x86_64+0x2f0578)
    #11 $s12 MyAPP14AccountManagerCACyc33_C85C7C4BB3D8F8348ADB1F78D4F8A637Llfc <null> ( MyAPP:x86_64+0x10034481a)
    #12 $s12 MyAPP14AccountManagerCACyc33_C85C7C4BB3D8F8348ADB1F78D4F8A637LlfC <null> ( MyAPP:x86_64+0x100343db8)
    #13 globalinit_33_C85C7C4BB3D8F8348ADB1F78D4F8A637_func1 <null> ( MyAPP:x86_64+0x100343d27)
    #14 dispatch_once <null> (libclang_rt.tsan_iossim_dynamic.dylib:x86_64+0x682d4)
    #15 dispatch_once_f <null> (libclang_rt.tsan_iossim_dynamic.dylib:x86_64+0x683c0)
    #16 swift_once <null> (libswiftCore.dylib:x86_64+0x2f0578)
    #17 $s12 MyAPP19DataServiceAssemblyV8assemble9containery8Swinject9ContainerC_tF <null> ( MyAPP:x86_64+0x1005b553b)
    #18 $s12 MyAPP19DataServiceAssemblyV8Swinject0E0AadEP8assemble9containeryAD9ContainerC_tFTW <null> ( MyAPP:x86_64+0x1005b5de0)
    #19 $s8Swinject9AssemblerC3run33_6BC9021A14E6F9B4DEC5F8BF06E74773LL10assembliesySayAA8Assembly_pG_tF <null> (Swinject:x86_64+0x2b57)
    #20 $s8Swinject9AssemblerC_9containerACSayAA8Assembly_pG_AA9ContainerCtcfc <null> (Swinject:x86_64+0x28a4)
    #21 $s8Swinject9AssemblerC_9containerACSayAA8Assembly_pG_AA9ContainerCtcfC <null> (Swinject:x86_64+0x27bb)
    #22 $s12 MyAPP14AppCoordinatorC6windowACSo8UIWindowC_tcfc <null> ( MyAPP:x86_64+0x1005c6dc7)
    #23 $s12 MyAPP14AppCoordinatorC6windowACSo8UIWindowC_tcfC <null> ( MyAPP:x86_64+0x1005c60b3)
    #24 $s12 MyAPP11AppDelegateC11application_30willFinishLaunchingWithOptionsSbSo13UIApplicationC_SDySo0k6LaunchJ3KeyaypGSgtF <null> ( MyAPP:x86_64+0x1008525f7)
    #25 $s12 MyAPP11AppDelegateC11application_30willFinishLaunchingWithOptionsSbSo13UIApplicationC_SDySo0k6LaunchJ3KeyaypGSgtFTo <null> ( MyAPP:x86_64+0x100852765)
    #26 -[UIApplication _handleDelegateCallbacksWithOptions:isSuspended:restoreState:] <null> (UIKitCore:x86_64+0x94529c)
    #27 start <null> (libdyld.dylib:x86_64+0x1540)

  Mutex M2680 (0x7b1800019ff0) created at:
    #0 pthread_mutex_init <null> (libclang_rt.tsan_iossim_dynamic.dylib:x86_64+0x297e3)
    #1 -[NSLock init] <null> (Foundation:x86_64+0x7cb77)
    #2 $sSo6NSLockCABycfC <null> (Starscream:x86_64+0x2c7df)
    #3 $s10Starscream9WebSocketC7request9protocols6streamAC10Foundation10URLRequestV_SaySSGSgAA8WSStream_ptcfc <null> (Starscream:x86_64+0x302e4)
    #4 $s10Starscream9WebSocketC7request9protocols6streamAC10Foundation10URLRequestV_SaySSGSgAA8WSStream_ptcfC <null> (Starscream:x86_64+0x2e82a)
    #5 $s10Starscream9WebSocketC3url9protocolsAC10Foundation3URLV_SaySSGSgtcfC <null> (Starscream:x86_64+0x31c43)
    #6 $s12 MyAPP8QZEngineC4openyyF <null> ( MyAPP:x86_64+0x100a414e9)
    #7 $s12 MyAPP8QZEngineC4typeAcA0C4TypeO_tc33_9DA9368FB478760390B65F344D9F1BEFLlfc <null> ( MyAPP:x86_64+0x100a3fde2)
    #8 $s12 MyAPP8QZEngineC4typeAcA0C4TypeO_tc33_9DA9368FB478760390B65F344D9F1BEFLlfC <null> ( MyAPP:x86_64+0x100a3eec6)
    #9 $s12 MyAPP8QZEngineC4mainACvpZfiACyXEfU_ <null> ( MyAPP:x86_64+0x100a420a7)
    #10 globalinit_33_9DA9368FB478760390B65F344D9F1BEF_func2 <null> ( MyAPP:x86_64+0x100a42035)
    #11 dispatch_once <null> (libclang_rt.tsan_iossim_dynamic.dylib:x86_64+0x682d4)
    #12 dispatch_once_f <null> (libclang_rt.tsan_iossim_dynamic.dylib:x86_64+0x683c0)
    #13 swift_once <null> (libswiftCore.dylib:x86_64+0x2f0578)
    #14 $s12 MyAPP14AccountManagerCACyc33_C85C7C4BB3D8F8348ADB1F78D4F8A637Llfc <null> ( MyAPP:x86_64+0x10034481a)
    #15 $s12 MyAPP14AccountManagerCACyc33_C85C7C4BB3D8F8348ADB1F78D4F8A637LlfC <null> ( MyAPP:x86_64+0x100343db8)
    #16 globalinit_33_C85C7C4BB3D8F8348ADB1F78D4F8A637_func1 <null> ( MyAPP:x86_64+0x100343d27)
    #17 dispatch_once <null> (libclang_rt.tsan_iossim_dynamic.dylib:x86_64+0x682d4)
    #18 dispatch_once_f <null> (libclang_rt.tsan_iossim_dynamic.dylib:x86_64+0x683c0)
    #19 swift_once <null> (libswiftCore.dylib:x86_64+0x2f0578)
    #20 $s12 MyAPP19DataServiceAssemblyV8assemble9containery8Swinject9ContainerC_tF <null> ( MyAPP:x86_64+0x1005b553b)
    #21 $s12 MyAPP19DataServiceAssemblyV8Swinject0E0AadEP8assemble9containeryAD9ContainerC_tFTW <null> ( MyAPP:x86_64+0x1005b5de0)
    #22 $s8Swinject9AssemblerC3run33_6BC9021A14E6F9B4DEC5F8BF06E74773LL10assembliesySayAA8Assembly_pG_tF <null> (Swinject:x86_64+0x2b57)
    #23 $s8Swinject9AssemblerC_9containerACSayAA8Assembly_pG_AA9ContainerCtcfc <null> (Swinject:x86_64+0x28a4)
    #24 $s8Swinject9AssemblerC_9containerACSayAA8Assembly_pG_AA9ContainerCtcfC <null> (Swinject:x86_64+0x27bb)
    #25 $s12 MyAPP14AppCoordinatorC6windowACSo8UIWindowC_tcfc <null> ( MyAPP:x86_64+0x1005c6dc7)
    #26 $s12 MyAPP14AppCoordinatorC6windowACSo8UIWindowC_tcfC <null> ( MyAPP:x86_64+0x1005c60b3)
atos[45422]: atos cannot examine process 45377 ( MyAPP) for unknown reasons, even though it appears to exist; try running with `sudo`.
    #27 $s12 MyAPP11AppDelegateC11application_30willFinishLaunchingWithOptionsSbSo13UIApplicationC_SDySo0k6LaunchJ3KeyaypGSgtF <null> ( MyAPP:x86_64+0x1008525f7)
    #28 $s12 MyAPP11AppDelegateC11application_30willFinishLaunchingWithOptionsSbSo13UIApplicationC_SDySo0k6LaunchJ3KeyaypGSgtFTo <null> ( MyAPP:x86_64+0x100852765)
    #29 -[UIApplication _handleDelegateCallbacksWithOptions:isSuspended:restoreState:] <null> (UIKitCore:x86_64+0x94529c)
    #30 start <null> (libdyld.dylib:x86_64+0x1540)

  Thread T1 (tid=1136835, running) is a GCD worker thread

  Thread T3 (tid=1136854, running) is a GCD worker thread

SUMMARY: ThreadSanitizer: data race (/Users/xiaochuan/Library/Developer/CoreSimulator/Devices/9160CE83-696D-469B-B3BB-AB1E8F0E1003/data/Containers/Bundle/Application/62998F83-2663-4735-8F2F-296321804C6C/ MyAPP.app/Frameworks/Starscream.framework/Starscream:x86_64+0x2c369) in $s10Starscream9WebSocketC9connected33_E91840E7069A0D2D302D042308E9D928LLSbvs
```