### PR TITLE
Fix crash when trying to connect with invalid url

### DIFF
--- a/Sources/Starscream/WebSocket.swift
+++ b/Sources/Starscream/WebSocket.swift
@@ -579,6 +579,7 @@ open class WebSocket : NSObject, StreamDelegate, WebSocketClient, WSStreamDelega
      */
     private func createHTTPRequest() {
         guard let url = request.url else {return}
+	guard url.scheme != nil, url.host != nil else {return}
         var port = url.port
         if port == nil {
             if supportedSSLSchemes.contains(url.scheme!) {


### PR DESCRIPTION
When using an invalid url (f.e. ",") and trying to connect it crashes when trying to access the scheme with `url.scheme!`.  With this change if the scheme or host is missing it will stop trying to connect in the same way it is done when request.url is not available.