### PR TITLE
Fix parsing HTTP responce header values which contains colon symbol

### DIFF
--- a/Sources/Starscream/WebSocket.swift
+++ b/Sources/Starscream/WebSocket.swift
@@ -868,10 +868,9 @@ open class WebSocket : NSObject, StreamDelegate, WebSocketClient, WSStreamDelega
                     code = c
                 }
             } else {
-                let responseSplit = str.components(separatedBy: ":")
-                guard responseSplit.count > 1 else { break }
-                let key = responseSplit[0].trimmingCharacters(in: .whitespaces)
-                let val = responseSplit[1].trimmingCharacters(in: .whitespaces)
+                guard let separatorIndex = str.firstIndex(of: ":") else { break }
+                let key = str.prefix(upTo: separatorIndex).trimmingCharacters(in: .whitespaces)
+                let val = str.suffix(from: str.index(after: separatorIndex)).trimmingCharacters(in: .whitespaces)
                 headers[key.lowercased()] = val
             }
             i += 1


### PR DESCRIPTION
If HTTP value for header contains ":" character, than prev. implementation will take only first part of the value till ":" char and ignore everything else.
Example: "Date: Tue, 04 Jun 2019 13:55:20 GMT" => headers["date"] = "Tue, 04 Jun 2019 13"

Please accept this bug fix and provide new release.
Thanks for considering my request.
