### PR TITLE
Always wait for currently executing operations to finish

### DIFF
--- a/Sources/Starscream/WebSocket.swift
+++ b/Sources/Starscream/WebSocket.swift
@@ -723,11 +723,11 @@ open class WebSocket : NSObject, StreamDelegate, WebSocketClient, WSStreamDelega
      Disconnect the stream object and notifies the delegate.
      */
     private func disconnectStream(_ error: Error?, runDelegate: Bool = true) {
-        if error == nil {
-            writeQueue.waitUntilAllOperationsAreFinished()
-        } else {
+        if error != nil {
             writeQueue.cancelAllOperations()
         }
+
+        writeQueue.waitUntilAllOperationsAreFinished()
         
         mutex.lock()
         cleanupStream()


### PR DESCRIPTION
We should always be waiting until currently executing operations have completed before we set outputStream to nil, and avoid another concurrentOperation from accessing a nil outputStream.

Per the documentation on `cancelAllOperations`: https://developer.apple.com/documentation/foundation/nsoperationqueue/1417849-cancelalloperations

```Canceling the operations does not automatically remove them from the queue or stop those that are currently executing```