### PR TITLE
Fix for a buffer overflow when close code has not been received from the socket

### DIFF
--- a/Sources/Framer/Framer.swift
+++ b/Sources/Framer/Framer.swift
@@ -183,6 +183,9 @@ public class WSFramer: Framer {
                 closeCode = CloseCode.protocolError.rawValue
                 dataLength = 0
             } else if payloadLen > 1 {
+                if pointer.count < 4 {
+                    return .needsMoreData
+                }
                 let size = MemoryLayout<UInt16>.size
                 closeCode = pointer.readUint16(offset: offset)
                 offset += size


### PR DESCRIPTION
I encountered the crash here where `pointer` only contained two bytes, [136, 39] and it was trying to read `closeCode` from outside the buffer. This should fix it.