### PR TITLE
Enable SSL in FoundationTransport for secure hosts

### DIFF
--- a/Sources/Transport/FoundationTransport.swift
+++ b/Sources/Transport/FoundationTransport.swift
@@ -66,6 +66,12 @@ public class FoundationTransport: NSObject, Transport, StreamDelegate {
         inStream.delegate = self
         outStream.delegate = self
     
+        if isTLS {
+            let key = CFStreamPropertyKey(rawValue: kCFStreamPropertySocketSecurityLevel)
+            CFReadStreamSetProperty(inStream, key, kCFStreamSocketSecurityLevelNegotiatedSSL)
+            CFWriteStreamSetProperty(outStream, key, kCFStreamSocketSecurityLevelNegotiatedSSL)
+        }
+        
         onConnect?(inStream, outStream)
         
         isOpen = false


### PR DESCRIPTION
This fixes connection to secure hosts such as wss://echo.websocket.org

The `kCFStreamPropertySocketSecurityLevel` property needs to be set for the CFStream(s) to negotiate a secure connection with the server.

- Fixes https://github.com/daltoniam/Starscream/issues/748
- Fixes https://github.com/daltoniam/Starscream/issues/728