### PR TITLE
Fix the deadlock issue on iOS 11

### DIFF
--- a/Sources/DataBytes/Data+Extensions.swift
+++ b/Sources/DataBytes/Data+Extensions.swift
@@ -27,22 +27,20 @@ import Foundation
 internal extension Data {
     struct ByteError: Swift.Error {}
     
+    #if swift(>=5.0)
     func withUnsafeBytes<ResultType, ContentType>(_ completion: (UnsafePointer<ContentType>) throws -> ResultType) rethrows -> ResultType {
-        #if swift(>=5.0)
-        return try withUnsafeBytes { 
+        return try withUnsafeBytes {
             if let baseAddress = $0.baseAddress, $0.count > 0 {
                 return try completion(baseAddress.assumingMemoryBound(to: ContentType.self))
             } else {
                 throw ByteError()
             }
         }
-        #else
-        return try withUnsafeBytes(completion)
-        #endif
     }
+    #endif
     
+    #if swift(>=5.0)
     mutating func withUnsafeMutableBytes<ResultType, ContentType>(_ completion: (UnsafeMutablePointer<ContentType>) throws -> ResultType) rethrows -> ResultType {
-        #if swift(>=5.0)
         return try withUnsafeMutableBytes {
             if let baseAddress = $0.baseAddress, $0.count > 0 {
                 return try completion(baseAddress.assumingMemoryBound(to: ContentType.self))
@@ -50,8 +48,6 @@ internal extension Data {
                 throw ByteError()
             }
         }
-        #else
-        return try withUnsafeMutableBytes(completion)
-        #endif
     }
+    #endif
 }


### PR DESCRIPTION
If the swift version is less than 5.0 instead of calling the default function: https://developer.apple.com/documentation/swift/2632391-withunsafemutablebytes 
it calls itself causing a deadlock.