### PR TITLE
feat(waiting): add error handling for errors while waiting

### DIFF
--- a/Sources/Engine/WSEngine.swift
+++ b/Sources/Engine/WSEngine.swift
@@ -120,7 +120,10 @@ FrameCollectorDelegate, HTTPHandlerDelegate {
             let wsReq = HTTPWSHeader.createUpgrade(request: request, supportsCompression: framer.supportsCompression(), secKeyValue: secKeyValue)
             let data = httpHandler.convert(request: wsReq)
             transport.write(data: data, completion: {_ in })
-        case .waiting:
+        case .waiting(let error):
+            if let error = error {
+                handleError(error);
+            }
             break
         case .failed(let error):
             handleError(error)

--- a/Sources/Transport/TCPTransport.swift
+++ b/Sources/Transport/TCPTransport.swift
@@ -105,8 +105,8 @@ public class TCPTransport: Transport {
             switch newState {
             case .ready:
                 self?.delegate?.connectionChanged(state: .connected)
-            case .waiting:
-                self?.delegate?.connectionChanged(state: .waiting)
+            case .waiting(let error):
+                self?.delegate?.connectionChanged(state: .waiting(error))
             case .cancelled:
                 self?.delegate?.connectionChanged(state: .cancelled)
             case .failed(let error):

--- a/Sources/Transport/Transport.swift
+++ b/Sources/Transport/Transport.swift
@@ -26,7 +26,7 @@ import Foundation
 
 public enum ConnectionState {
     case connected
-    case waiting
+    case waiting(Error?)
     case cancelled
     case failed(Error?)
     


### PR DESCRIPTION
While using a custom cert pinnner calling `completion(.failed(error))` will update the state with state `waiting` passing the cert error. 

In this case we also should call the error handler.
