### PR TITLE
Remove tls handling override when no pinner provided

### DIFF
--- a/Sources/Transport/TCPTransport.swift
+++ b/Sources/Transport/TCPTransport.swift
@@ -59,13 +59,9 @@ public class TCPTransport: Transport {
         options.connectionTimeout = Int(timeout.rounded(.up))
 
         let tlsOptions = isTLS ? NWProtocolTLS.Options() : nil
-        if let tlsOpts = tlsOptions {
+        if let tlsOpts = tlsOptions, let pinner = certificatePinning {
             sec_protocol_options_set_verify_block(tlsOpts.securityProtocolOptions, { (sec_protocol_metadata, sec_trust, sec_protocol_verify_complete) in
                 let trust = sec_trust_copy_ref(sec_trust).takeRetainedValue()
-                guard let pinner = certificatePinning else {
-                    sec_protocol_verify_complete(true)
-                    return
-                }
                 pinner.evaluateTrust(trust: trust, domain: parts.host, completion: { (state) in
                     switch state {
                     case .success:


### PR DESCRIPTION
When no pinner was provided, it is expected that framework will use
whatever iOS will provide. But instead - it will allow ALL
connections, bypassing any verification.
This is breaking change, but most clients of the library probably
never had to do that.
Client can still allow selfSigned certs with FoundationSecurityError.allowSelfSigned.