### PR TITLE
In FoundationTransport deinit, remove self as a delegate to InputStream and OutputStream to prevent EXC_BAD_ACCESS

### DIFF
--- a/Sources/Transport/FoundationTransport.swift
+++ b/Sources/Transport/FoundationTransport.swift
@@ -47,7 +47,12 @@ public class FoundationTransport: NSObject, Transport, StreamDelegate {
         onConnect = streamConfiguration
     }
     
-     public func connect(url: URL, timeout: Double = 10, certificatePinning: CertificatePinning? = nil) {
+    deinit {
+        inputStream?.delegate = nil
+        outputStream?.delegate = nil
+    }
+    
+    public func connect(url: URL, timeout: Double = 10, certificatePinning: CertificatePinning? = nil) {
         guard let parts = url.getParts() else {
             delegate?.connectionChanged(state: .failed(FoundationTransportError.invalidRequest))
             return


### PR DESCRIPTION
As mentioned by @nickoto in #676 and #773, Starscream will crash if a socket is deallocated before it finishes disconnecting when using `FoundationTransport`.  In my own testing, simply setting the delegates to `inputStream` and `outputStream` to `nil` in `deinit` is effective at preventing the crash.  This makes a fair amount of sense, since [`Stream.delegate` is an `unowned` property](https://developer.apple.com/documentation/foundation/stream/1418423-delegate).