### PR TITLE
Fix error when trying to convert text message partial payload to UTF-8

### DIFF
--- a/Sources/Framer/FrameCollector.swift
+++ b/Sources/Framer/FrameCollector.swift
@@ -84,19 +84,15 @@ public class FrameCollector {
         }
         buffer.append(payload)
         frameCount += 1
-        if isText {
-            if String(data: buffer, encoding: .utf8) == nil {
-                let errCode = CloseCode.protocolError.rawValue
-                delegate?.didForm(event: .error(WSError(type: .protocolError, message: "not valid UTF-8 data", code: errCode)))
-                reset()
-                return
-            }
-        }
-        
+
         if frame.isFin {
             if isText {
-                let string = String(data: buffer, encoding: .utf8) ?? ""
-                delegate?.didForm(event: .text(string))
+                if let string = String(data: buffer, encoding: .utf8) {
+                    delegate?.didForm(event: .text(string))
+                } else {
+                    let errCode = CloseCode.protocolError.rawValue
+                    delegate?.didForm(event: .error(WSError(type: .protocolError, message: "not valid UTF-8 data", code: errCode)))
+                }
             } else {
                 delegate?.didForm(event: .binary(buffer))
             }


### PR DESCRIPTION
There was an issue with "not valid UTF-8 data" error being returned sometimes for incoming text messages that were split into multiple frames. If incoming text message consists of multiple frames, buffered partial payload may not necessarily represent a valid UTF-8 string, only a whole received message must represent a valid UTF-8 string. So we have to check if buffered payload of text message can be converted to a UTF-8 string only after receiving all frames of incoming text message, and only then try to convert to UTF-8 string and return error if it was not valid.