### PR TITLE
Improve conditions for calling readLoop() and prevent infinite looping

### DIFF
--- a/Sources/Transport/TCPTransport.swift
+++ b/Sources/Transport/TCPTransport.swift
@@ -141,7 +141,16 @@ public class TCPTransport: Transport {
             if let data = data {
                 s.delegate?.connectionChanged(state: .receive(data))
             }
-            s.readLoop()
+            
+            // Refer to https://developer.apple.com/documentation/network/implementing_netcat_with_network_framework
+            if let context = context, context.isFinal, isComplete {
+                return
+            }
+            
+            if error == nil {
+                s.readLoop()
+            }
+
         })
     }
 }


### PR DESCRIPTION
This is a fix for https://github.com/daltoniam/Starscream/issues/786 . 

Taken from Apple's sample code for `Network.framework` https://developer.apple.com/documentation/network/implementing_netcat_with_network_framework 

Specifically:
```c
dispatch_block_t schedule_next_receive = ^{
    // If the context is marked as complete, and is the final context,
    // we're read-closed.
    if (is_complete &&
        context != NULL && nw_content_context_get_is_final(context)) {
        exit(0);
    }

    // If there was no error in receiving, request more data
    if (receive_error == NULL) {
        receive_loop(connection);
    }
};
```