### PR TITLE
Switch SPM to use Swift 5.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.2
 
 //
 //  Package.Swift


### PR DESCRIPTION
Since if you install Starscream via Cocoapods, it will use Swift 5.0, and the project file also uses 5.x. So there doesn't appear to be a reason for SPM to be limited to 4.2.