### PR TITLE
Fix compile error on Xcode 12

### DIFF
--- a/Sources/Framer/FoundationHTTPServerHandler.swift
+++ b/Sources/Framer/FoundationHTTPServerHandler.swift
@@ -74,7 +74,7 @@ public class FoundationHTTPServerHandler: HTTPServerHandler {
             return false //not enough data, wait for more
         }
         if let method = CFHTTPMessageCopyRequestMethod(response)?.takeRetainedValue() {
-            if method != getVerb {
+            if (method as NSString) != getVerb {
                 delegate?.didReceive(event: .failure(HTTPUpgradeError.invalidData))
                 return true
             }

--- a/Starscream.xcodeproj/project.pbxproj
+++ b/Starscream.xcodeproj/project.pbxproj
@@ -38,6 +38,16 @@
 		BBB5ABE8215E2217005B48B6 /* WebSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB5ABE4215E2217005B48B6 /* WebSocket.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		6B0BE7AA24A157BB0051F7A7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 6B3E79DD19D48B7F006071F7 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 33CCF0841F5DDC030099B092;
+			remoteInfo = Starscream;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
 		335FA2021F5DF71D00F6D2EC /* Starscream Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Starscream Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		33CCF0921F5DDC030099B092 /* Starscream.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Starscream.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -250,6 +260,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				6B0BE7AB24A157BB0051F7A7 /* PBXTargetDependency */,
 			);
 			name = "Starscream Tests";
 			productName = StarscreamTests;
@@ -371,6 +382,14 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		6B0BE7AB24A157BB0051F7A7 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 33CCF0841F5DDC030099B092 /* Starscream */;
+			targetProxy = 6B0BE7AA24A157BB0051F7A7 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		335FA2001F5DF71D00F6D2EC /* Debug */ = {


### PR DESCRIPTION
Now you can build on both Xcode 11.5 & 12.0 b1.

On 12, the unit tests would fail to compile because it wasn't finding the `Starscream` framework. So I added `Starscream` as a dependency of the test target.

In `FoundationHTTPServerHandler` the `method` is of type `CFString`, while `getVerb` is `NSString`. Looks like Xcode 12 doesn't like equality comparison between those types without a cast as `NSString`.