### PR TITLE
Compare between CFString and NSString

### DIFF
--- a/Sources/Framer/FoundationHTTPServerHandler.swift
+++ b/Sources/Framer/FoundationHTTPServerHandler.swift
@@ -74,7 +74,7 @@ public class FoundationHTTPServerHandler: HTTPServerHandler {
             return false //not enough data, wait for more
         }
         if let method = CFHTTPMessageCopyRequestMethod(response)?.takeRetainedValue() {
-            if method != getVerb {
+            if (method as NSString) != getVerb {
                 delegate?.didReceive(event: .failure(HTTPUpgradeError.invalidData))
                 return true
             }


### PR DESCRIPTION
When using Startscream in my Mac project on the new Apple Silicon DTK, I found an issue in this comparison between an NSString and CFString. I don't know why but this made the machine happy. Hope this is useful for the project!