### PR TITLE
Conditionally include 'swift-nio-zlib-support' dependency to avoid warning on macOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,11 +27,13 @@ let package = Package(
         products: [
             .library(name: "Starscream", targets: ["Starscream"])
         ],
-        dependencies: [
-          .package(url: "https://github.com/apple/swift-nio-zlib-support.git", from: "1.0.0")
-        ],
+        dependencies: [],
         targets: [
             .target(name: "Starscream",
                     path: "Sources")
         ]
 )
+
+#if os(Linux)
+    package.dependencies.append(.package(url: "https://github.com/apple/swift-nio-zlib-support.git", from: "1.0.0"))
+#endif


### PR DESCRIPTION
This PR removes an ugly Xcode warning (https://github.com/daltoniam/Starscream/issues/719)
<img width="283" alt="image" src="https://user-images.githubusercontent.com/6864532/87257833-1d659300-c4a7-11ea-9fef-0f156c329ebb.png">