### PR TITLE
prevent duplicate connect

### DIFF
--- a/Sources/Transport/TCPTransport.swift
+++ b/Sources/Transport/TCPTransport.swift
@@ -50,6 +50,9 @@ public class TCPTransport: Transport {
     }
     
     public func connect(url: URL, timeout: Double = 10, certificatePinning: CertificatePinning? = nil) {
+        if connection != nil {
+            return
+        }
         guard let parts = url.getParts() else {
             delegate?.connectionChanged(state: .failed(TCPTransportError.invalidRequest))
             return


### PR DESCRIPTION
once we create transport with `connection` argument, we don't want it to be recreated during `transport.start`