### PR TITLE
Allow WebSocketDelegate 'didReceive' method's 'client' parameter to work with `WebSocketClient` mock objects

### DIFF
--- a/Sources/Starscream/WebSocket.swift
+++ b/Sources/Starscream/WebSocket.swift
@@ -88,7 +88,7 @@ public enum WebSocketEvent {
 }
 
 public protocol WebSocketDelegate: class {
-    func didReceive(event: WebSocketEvent, client: WebSocket)
+    func didReceive(event: WebSocketEvent, client: WebSocketClient)
 }
 
 open class WebSocket: WebSocketClient, EngineDelegate {


### PR DESCRIPTION
Resolves #811 