### PR TITLE
Feature/pass on timeout

### DIFF
--- a/Sources/Engine/WSEngine.swift
+++ b/Sources/Engine/WSEngine.swift
@@ -122,6 +122,8 @@ FrameCollectorDelegate, HTTPHandlerDelegate {
             transport.write(data: data, completion: {_ in })
         case .waiting:
             break
+        case .timedout:
+            broadcast(event: .timedout)
         case .failed(let error):
             handleError(error)
         case .viability(let isViable):

--- a/Sources/Server/WebSocketServer.swift
+++ b/Sources/Server/WebSocketServer.swift
@@ -123,6 +123,8 @@ public class ServerConnection: Connection, HTTPServerDelegate, FramerEventClient
             break
         case .waiting:
             break
+        case .timedout:
+            break
         case .failed(let error):
             print("server connection error: \(error ?? WSError(type: .protocolError, message: "default error, no extra data", code: 0))") //handleError(error)
         case .viability(_):

--- a/Sources/Starscream/WebSocket.swift
+++ b/Sources/Starscream/WebSocket.swift
@@ -85,6 +85,7 @@ public enum WebSocketEvent {
     case viabilityChanged(Bool)
     case reconnectSuggested(Bool)
     case cancelled
+    case timedout
 }
 
 public protocol WebSocketDelegate: class {

--- a/Sources/Transport/TCPTransport.swift
+++ b/Sources/Transport/TCPTransport.swift
@@ -105,8 +105,17 @@ public class TCPTransport: Transport {
             switch newState {
             case .ready:
                 self?.delegate?.connectionChanged(state: .connected)
-            case .waiting:
-                self?.delegate?.connectionChanged(state: .waiting)
+            case .waiting(let error):
+                switch error {
+                case .posix(let errorCode):
+                    if(errorCode == .ETIMEDOUT){
+                        self?.delegate?.connectionChanged(state: .timedout)
+                    }else{
+                        self?.delegate?.connectionChanged(state: .waiting)
+                    }
+                default:
+                    self?.delegate?.connectionChanged(state: .waiting)
+                }
             case .cancelled:
                 self?.delegate?.connectionChanged(state: .cancelled)
             case .failed(let error):

--- a/Sources/Transport/Transport.swift
+++ b/Sources/Transport/Transport.swift
@@ -28,6 +28,7 @@ public enum ConnectionState {
     case connected
     case waiting
     case cancelled
+    case timedout
     case failed(Error?)
     
     //the viability (connection status) of the connection has updated


### PR DESCRIPTION
When setting a timeoutInterval for the URLRequest, so far it was not possible to handle this timeout exception. 

Example Code:
```
var request = URLRequest(url: URL(string: "ws://localhost:8080/")!)
request.timeoutInterval = 5 // Sets the timeout for the connection
```

A new event 'timedout' is introduced to handle this scenario.