### PR TITLE
Add Issue templates and PR templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: Bug report
+about: Create a report about a bug
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+### Describe the bug
+> A clear and concise description of what the bug is.
+
+### Steps to Reproduce
+> Detailed steps to reproduce the problematic behavior:
+
+### Expected behavior
+> A clear and concise description of what you expected to happen.
+
+### Environment:
+- OS/Version: [e.g. iOS/13.3]
+- Starscream Version [e.g. 4.0.4]
+- Xcode version [e.g. 11.5]
+
+### Additional context
+> Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: feature_request
+assignees: ''
+
+---
+
+### What do you want to happen?
+> Please replace this with the general overview of the feature that you'd like to have.  
+
+### What happens now?
+> Please replace this with of what is happening currently.  
+
+### Demo Code
+> Any demo code that may used to implement/use the desired feature. 
+
+### Describe alternatives you've considered
+> A clear and concise description of any alternative solutions or features you've considered.
+
+### Additional context
+> Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/general-question.md
+++ b/.github/ISSUE_TEMPLATE/general-question.md
@@ -1,0 +1,16 @@
+---
+name: General Question
+about: 'Ask any question about the framework. '
+title: ''
+labels: question
+assignees: ''
+
+---
+
+### Question
+> A description of what you want to know.
+
+### Environment:
+- OS/Version: [e.g. iOS/13.3]
+- Starscream Version [e.g. 4.0.4]
+- Xcode version [e.g. 11.5]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+### Issue Link 🔗
+> Please attach the link to an issue if it exists.
+
+### Goals ⚽
+> What you hope to address within this PR.
+
+### Implementation Details 🚧
+> Additional details about the PR. 


### PR DESCRIPTION
### Goals ⚽
I've been looking through the Issues to find some issues to triage, but found many issues without any details about them. I figured that we would benefit a lot from using issue/PR templates and getting more information about the problems. 

Please let me know if you think different format/types should be used to these templates. 

### Implementation Details 🚧
Added `bug_report.md`, `general-questions.md`, and `feature_request.md` for issue templates, and `pull_request_template.md` for PR template.