### PR TITLE
Remove three unused properties

### DIFF
--- a/Sources/Starscream/WebSocket.swift
+++ b/Sources/Starscream/WebSocket.swift
@@ -110,11 +110,6 @@ open class WebSocket: WebSocketClient, EngineDelegate {
         }
     }
     
-    // serial write queue to ensure writes happen in order
-    private let writeQueue = DispatchQueue(label: "com.vluxe.starscream.writequeue")
-    private var canSend = false
-    private let mutex = DispatchSemaphore(value: 1)
-    
     public init(request: URLRequest, engine: Engine) {
         self.request = request
         self.engine = engine


### PR DESCRIPTION
These three properties in `WebSocket` class are never used, so maybe it's better to remove them

```swift
    private let writeQueue = DispatchQueue(label: "com.vluxe.starscream.writequeue")
    private var canSend = false
    private let mutex = DispatchSemaphore(value: 1)
```