### PR TITLE
Add Headers to `notAnUpgrade` error.

### DIFF
--- a/Sources/Framer/FoundationHTTPHandler.swift
+++ b/Sources/Framer/FoundationHTTPHandler.swift
@@ -76,12 +76,6 @@ public class FoundationHTTPHandler: HTTPHandler {
             return false //not enough data, wait for more
         }
         
-        let code = CFHTTPMessageGetResponseStatusCode(response)
-        if code != HTTPWSHeader.switchProtocolCode {
-            delegate?.didReceiveHTTP(event: .failure(HTTPUpgradeError.notAnUpgrade(code)))
-            return true
-        }
-        
         if let cfHeaders = CFHTTPMessageCopyAllHeaderFields(response) {
             let nsHeaders = cfHeaders.takeRetainedValue() as NSDictionary
             var headers = [String: String]()
@@ -90,6 +84,13 @@ public class FoundationHTTPHandler: HTTPHandler {
                     headers[key] = value
                 }
             }
+            
+            let code = CFHTTPMessageGetResponseStatusCode(response)
+            if code != HTTPWSHeader.switchProtocolCode {
+                delegate?.didReceiveHTTP(event: .failure(HTTPUpgradeError.notAnUpgrade(code, headers)))
+                return true
+            }
+            
             delegate?.didReceiveHTTP(event: .success(headers))
             return true
         }

--- a/Sources/Framer/HTTPHandler.swift
+++ b/Sources/Framer/HTTPHandler.swift
@@ -23,7 +23,7 @@
 import Foundation
 
 public enum HTTPUpgradeError: Error {
-    case notAnUpgrade(Int)
+    case notAnUpgrade(Int, [String: String])
     case invalidData
 }
 

--- a/Sources/Framer/StringHTTPHandler.swift
+++ b/Sources/Framer/StringHTTPHandler.swift
@@ -110,7 +110,7 @@ public class StringHTTPHandler: HTTPHandler {
         }
         
         if code != HTTPWSHeader.switchProtocolCode {
-            delegate?.didReceiveHTTP(event: .failure(HTTPUpgradeError.notAnUpgrade(code)))
+            delegate?.didReceiveHTTP(event: .failure(HTTPUpgradeError.notAnUpgrade(code, headers)))
             return true
         }
         


### PR DESCRIPTION
Some Websocket servers require Auth on the HTTP connection. They will use the WWW-Authenticate header to indicate why this fails. 

The WWW-Authenticate header is used to includes information about what token/scope you need to acquire.  Due to this it is important that if the WS connection fails to connect that the headers are included in that error so that the application can determine the nature of the authentication errors (eg token expired, or wrong scope etc). 

For example:
```http
     HTTP/1.1 401 Unauthorized
     WWW-Authenticate: Bearer realm="example",
                       error="insufficient_scope",
                       scope="USEast",
                       error_description="Requires scope USEast to access."
```

Other use cases of the response header include error Tracing IDs these are very useful if the server responses with an error (500) if we are able to capture the tracing ID when the user files a report in the application it can be linked to the server side stack trace. 