### PR TITLE
Explicitly set domain to the passed value

### DIFF
--- a/Sources/Security/FoundationSecurity.swift
+++ b/Sources/Security/FoundationSecurity.swift
@@ -44,9 +44,7 @@ extension FoundationSecurity: CertificatePinning {
             return
         }
         
-        if let validateDomain = domain {
-            SecTrustSetPolicies(trust, SecPolicyCreateSSL(true, validateDomain as NSString?))
-        }
+        SecTrustSetPolicies(trust, SecPolicyCreateSSL(true, domain as NSString?))
         
         handleSecurityTrust(trust: trust, completion: completion)
     }


### PR DESCRIPTION
When using DNS names as the address, using the default trust settings are still resulting in a trust failure due to the hostname, even when setting the hostname to nil when calling evaluateTrust. However if the trust hostname is explicitly set to nil, then the trust is allowed to pass.  The trust apparently needs the hostname explicitly set to nil when using DNS names and you want the hostname ignored.  I've found that the behavior of the trust evaluation is different when using DNS names as opposed to when using IP addresses.

This change simply allows the hostname to be explicitly set in the trust to whatever value is passed in, whether that be nil or a value.