### PR TITLE
Xcode 12.5: Using ‘class’ keyword for protocol inheritance is deprecated; use ‘AnyObject’ instead

### DIFF
--- a/Sources/Engine/Engine.swift
+++ b/Sources/Engine/Engine.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public protocol EngineDelegate: class {
+public protocol EngineDelegate: AnyObject {
     func didReceive(event: WebSocketEvent)
 }
 

--- a/Sources/Framer/FrameCollector.swift
+++ b/Sources/Framer/FrameCollector.swift
@@ -22,7 +22,7 @@
 
 import Foundation
 
-public protocol FrameCollectorDelegate: class {
+public protocol FrameCollectorDelegate: AnyObject {
     func didForm(event: FrameCollector.Event)
     func decompress(data: Data, isFinal: Bool) -> Data?
 }

--- a/Sources/Framer/Framer.swift
+++ b/Sources/Framer/Framer.swift
@@ -71,7 +71,7 @@ public enum FrameEvent {
     case error(Error)
 }
 
-public protocol FramerEventClient: class {
+public protocol FramerEventClient: AnyObject {
     func frameProcessed(event: FrameEvent)
 }
 

--- a/Sources/Framer/HTTPHandler.swift
+++ b/Sources/Framer/HTTPHandler.swift
@@ -94,7 +94,7 @@ public enum HTTPEvent {
     case failure(Error)
 }
 
-public protocol HTTPHandlerDelegate: class {
+public protocol HTTPHandlerDelegate: AnyObject {
     func didReceiveHTTP(event: HTTPEvent)
 }
 
@@ -104,7 +104,7 @@ public protocol HTTPHandler {
     func parse(data: Data) -> Int
 }
 
-public protocol HTTPServerDelegate: class {
+public protocol HTTPServerDelegate: AnyObject {
     func didReceive(event: HTTPEvent)
 }
 

--- a/Sources/Security/Security.swift
+++ b/Sources/Security/Security.swift
@@ -34,12 +34,12 @@ public enum PinningState {
 
 // CertificatePinning protocol provides an interface for Transports to handle Certificate
 // or Public Key Pinning.
-public protocol CertificatePinning: class {
+public protocol CertificatePinning: AnyObject {
     func evaluateTrust(trust: SecTrust, domain: String?, completion: ((PinningState) -> ()))
 }
 
 // validates the "Sec-WebSocket-Accept" header as defined 1.3 of the RFC 6455
 // https://tools.ietf.org/html/rfc6455#section-1.3
-public protocol HeaderValidator: class {
+public protocol HeaderValidator: AnyObject {
     func validate(headers: [String: String], key: String) -> Error?
 }

--- a/Sources/Server/Server.swift
+++ b/Sources/Server/Server.swift
@@ -36,7 +36,7 @@ public protocol Connection {
     func write(data: Data, opcode: FrameOpCode)
 }
 
-public protocol ConnectionDelegate: class {
+public protocol ConnectionDelegate: AnyObject {
     func didReceive(event: ServerEvent)
 }
 

--- a/Sources/Starscream/WebSocket.swift
+++ b/Sources/Starscream/WebSocket.swift
@@ -41,7 +41,7 @@ public struct WSError: Error {
     }
 }
 
-public protocol WebSocketClient: class {
+public protocol WebSocketClient: AnyObject {
     func connect()
     func disconnect(closeCode: UInt16)
     func write(string: String, completion: (() -> ())?)
@@ -87,7 +87,7 @@ public enum WebSocketEvent {
     case cancelled
 }
 
-public protocol WebSocketDelegate: class {
+public protocol WebSocketDelegate: AnyObject {
     func didReceive(event: WebSocketEvent, client: WebSocketClient)
 }
 

--- a/Sources/Transport/Transport.swift
+++ b/Sources/Transport/Transport.swift
@@ -42,11 +42,11 @@ public enum ConnectionState {
     case receive(Data)
 }
 
-public protocol TransportEventClient: class {
+public protocol TransportEventClient: AnyObject {
     func connectionChanged(state: ConnectionState)
 }
 
-public protocol Transport: class {
+public protocol Transport: AnyObject {
     func register(delegate: TransportEventClient)
     func connect(url: URL, timeout: Double, certificatePinning: CertificatePinning?)
     func disconnect()


### PR DESCRIPTION
Hi @daltoniam, Thanks for considering this fix.
### Issue Link 🔗
https://docs.swift.org/swift-book/LanguageGuide/Protocols.html#ID281

### Goals ⚽
Avoid having warning when you are building on Xcode 12.5.

### Implementation Details 🚧
Replace all the class with AnyObject due to the deprecation.

- https://github.com/apple/swift-evolution/blob/master/proposals/0156-subclass-existentials.md