### PR TITLE
Added support for connection error

### DIFF
--- a/Sources/Engine/NativeEngine.swift
+++ b/Sources/Engine/NativeEngine.swift
@@ -94,4 +94,8 @@ public class NativeEngine: NSObject, Engine, URLSessionDataDelegate, URLSessionW
         }
         broadcast(event: .disconnected(r, UInt16(closeCode.rawValue)))
     }
+    
+    public func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        broadcast(event: .error(error))
+    }
 }


### PR DESCRIPTION
### Issue Link 🔗
> https://github.com/daltoniam/Starscream/issues/911

### Goals ⚽
> Native engine should emit an error when the endpoint does not exist. The current implementation does not fire any event when the server is not reachable or the URL is wrong.

### Implementation Details 🚧
> Added `didCompleteWithError` a `URLSessionTaskDelegate` that informs its delegate about clientSide connection errors
