### PR TITLE
drop unnecessary archs

### DIFF
--- a/Starscream.xcodeproj/project.pbxproj
+++ b/Starscream.xcodeproj/project.pbxproj
@@ -467,6 +467,8 @@
 		33CCF0911F5DDC030099B092 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				"ARCHS[sdk=iphoneos*]" = arm64;
+				"ARCHS[sdk=iphonesimulator*]" = x86_64;
 				BITCODE_GENERATION_MODE = bitcode;
 				CLANG_ENABLE_MODULES = YES;
 				DEFINES_MODULE = YES;


### PR DESCRIPTION
### Goals ⚽
> Remove unnecessary architectures in the xcframeworks, e.g. i386, armv7...

### Implementation Details 🚧
> Only build arm64 for device and x86_64 for simulator 
