### PR TITLE
Add Pong broadcast for NativeEngine

### DIFF
--- a/Sources/Engine/NativeEngine.swift
+++ b/Sources/Engine/NativeEngine.swift
@@ -49,8 +49,13 @@ public class NativeEngine: NSObject, Engine, URLSessionDataDelegate, URLSessionW
             let text = String(data: data, encoding: .utf8)!
             write(string: text, completion: completion)
         case .ping:
-            task?.sendPing(pongReceiveHandler: { (error) in
-                completion?()
+            task?.sendPing(pongReceiveHandler: { [weak self] (error) in
+                defer { completion?() }
+                if let error = error {
+                    self?.broadcast(event: .error(error))
+                    return
+                }
+                self?.broadcast(event: .pong(nil))
             })
         default:
             break //unsupported


### PR DESCRIPTION
### Issue
Never get pong event on iOS 13.0. It turns out that on iOS 13, Starscream using NativeEngine which is based on `URLSessionWebSocketTask` and does nothing on pongReceiveHandler other than just running completion. 

### Goals ⚽
pong event is broadcasted by NativeEngine

### Implementation Details 🚧
As per Apple documentation [here](https://developer.apple.com/documentation/foundation/urlsessionwebsockettask/3181206-sendping), `sendPing(pongReceiveHandler:)` method will execute its pongReceiveHandler whenever it receiving pong from the server or getting an error. So I added a broadcast error and pong inside this receiveHandler so it could be handled by WebSocketDelegate.