### PR TITLE
Fix compression when headers don't include window bits

### DIFF
--- a/Sources/Compression/WSCompression.swift
+++ b/Sources/Compression/WSCompression.swift
@@ -44,6 +44,10 @@ public class WSCompression: CompressionHandler {
         guard let extensionHeader = headers[headerWSExtensionName] else { return }
         decompressorTakeOver = false
         compressorTakeOver = false
+
+        // assume defaults unless the headers say otherwise
+        compressor = Compressor(windowBits: 15)
+        decompressor = Decompressor(windowBits: 15)
         
         let parts = extensionHeader.components(separatedBy: ";")
         for p in parts {
@@ -204,6 +208,11 @@ class Compressor {
     }
 
     func compress(_ data: Data) throws -> Data {
+        guard !data.isEmpty else {
+            // For example, PONG has no content
+            return data
+        }
+
         var compressed = Data()
         var res: CInt = 0
         data.withUnsafeBytes { (ptr:UnsafePointer<UInt8>) -> Void in


### PR DESCRIPTION
### Goals ⚽
When connecting to an aiohttp WebSocket, it excludes the `client_max_window_bits` and `server_max_window_bits` values [when at the default of 15](https://github.com/aio-libs/aiohttp/blob/eda8114ae1246aab135cef5201581025b4fb6fd0/aiohttp/http_websocket.py#L232).

### Implementation Details 🚧
This changes the compressor/decompressor to be created with the default unless otherwise specified. This also fixes a crash when trying to decode the PONG dataframe which has no content.