### PR TITLE
Fix for start websocket with cookies in initial request

### DIFF
--- a/Sources/Framer/HTTPHandler.swift
+++ b/Sources/Framer/HTTPHandler.swift
@@ -67,12 +67,14 @@ public struct HTTPWSHeader {
         req.setValue(HTTPWSHeader.versionValue, forHTTPHeaderField: HTTPWSHeader.versionName)
         req.setValue(secKeyValue, forHTTPHeaderField: HTTPWSHeader.keyName)
         
-        if let cookies = HTTPCookieStorage.shared.cookies(for: url), !cookies.isEmpty {
-            let headers = HTTPCookie.requestHeaderFields(with: cookies)
-            for (key, val) in headers {
-                req.setValue(val, forHTTPHeaderField: key)
+		if req.allHTTPHeaderFields?["Cookie"] == nil {
+            if let cookies = HTTPCookieStorage.shared.cookies(for: url), !cookies.isEmpty {
+                let headers = HTTPCookie.requestHeaderFields(with: cookies)
+                for (key, val) in headers {
+                    req.setValue(val, forHTTPHeaderField: key)
+                }
             }
-        }
+	     }
         
         if supportsCompression {
             let val = "permessage-deflate; client_max_window_bits; server_max_window_bits=15"


### PR DESCRIPTION
### Goals ⚽
The possibility to configure cookies per connection and not global

### Implementation Details 🚧
in some cases it may be necessary to pass some specific cookie to connection, but all cookies in the initiator request will be replaced by cookies in the cookie storage.
With this verification if the client pass a set of cookies in the initiator request these will used instead the ones in the cookie Storage
