### PR TITLE
fix: added peerClosed case for WebSocketEvent enum

### DIFF
--- a/Sources/Engine/WSEngine.swift
+++ b/Sources/Engine/WSEngine.swift
@@ -140,6 +140,8 @@ FrameCollectorDelegate, HTTPHandlerDelegate {
             }
         case .cancelled:
             broadcast(event: .cancelled)
+        case .peerClosed:
+            broadcast(event: .peerClosed)
         }
     }
     

--- a/Sources/Server/WebSocketServer.swift
+++ b/Sources/Server/WebSocketServer.swift
@@ -138,6 +138,8 @@ public class ServerConnection: Connection, HTTPServerDelegate, FramerEventClient
         case .cancelled:
             print("server connection cancelled!")
             //broadcast(event: .cancelled)
+        case .peerClosed:
+            delegate?.didReceive(event: .disconnected(self, "Connection closed by peer", UInt16(FrameOpCode.connectionClose.rawValue)))
         }
     }
     

--- a/Sources/Starscream/WebSocket.swift
+++ b/Sources/Starscream/WebSocket.swift
@@ -85,6 +85,7 @@ public enum WebSocketEvent {
     case viabilityChanged(Bool)
     case reconnectSuggested(Bool)
     case cancelled
+    case peerClosed
 }
 
 public protocol WebSocketDelegate: AnyObject {

--- a/Sources/Transport/TCPTransport.swift
+++ b/Sources/Transport/TCPTransport.swift
@@ -144,6 +144,13 @@ public class TCPTransport: Transport {
             
             // Refer to https://developer.apple.com/documentation/network/implementing_netcat_with_network_framework
             if let context = context, context.isFinal, isComplete {
+                if let delegate = s.delegate {
+                    // Let the owner of this TCPTransport decide what to do next: disconnect or reconnect?
+                    delegate.connectionChanged(state: .peerClosed)
+                } else {
+                    // No use to keep connection alive
+                    s.disconnect()
+                }
                 return
             }
             

--- a/Sources/Transport/Transport.swift
+++ b/Sources/Transport/Transport.swift
@@ -25,21 +25,31 @@
 import Foundation
 
 public enum ConnectionState {
+    /// Ready connections can send and receive data
     case connected
+    
+    /// Waiting connections have not yet been started, or do not have a viable network
     case waiting
+    
+    /// Cancelled connections have been invalidated by the client and will send no more events
     case cancelled
+    
+    /// Failed connections are disconnected and can no longer send or receive data
     case failed(Error?)
     
-    //the viability (connection status) of the connection has updated
-    //e.g. connection is down, connection came back up, etc
+    /// Viability (connection status) of the connection has updated
+    /// e.g. connection is down, connection came back up, etc.
     case viability(Bool)
     
-    //the connection has upgrade to wifi from cellular.
-    //you should consider reconnecting to take advantage of this
+    /// Connection ca be upgraded to wifi from cellular.
+    /// You should consider reconnecting to take advantage of this.
     case shouldReconnect(Bool)
     
-    //the connection receive data
+    /// Received data
     case receive(Data)
+    
+    /// Remote peer has closed the network connection.
+    case peerClosed
 }
 
 public protocol TransportEventClient: AnyObject {

--- a/Tests/FuzzingTests.swift
+++ b/Tests/FuzzingTests.swift
@@ -66,6 +66,8 @@ class FuzzingTests: XCTestCase {
                 break
             case .cancelled:
                 break
+            case .peerClosed:
+                break
             }
         }
         websocket.connect()


### PR DESCRIPTION
### Issue Link 🔗
https://github.com/daltoniam/Starscream/issues/935

### Goals ⚽
Fix the bug related to not receiving a message about a remotely closed connection by peer.

### Implementation Details 🚧
Added new `WebSocketEvent`. It eventually triggers a call of `TransportEventClient.connectionChanged` with value `.peerClosed`. It doesn't trigger reconnection. Reconnection, or different behaviour, should be implemented instead by the user of `WSEngine`.
