### PR TITLE
Bring #807 into v3.1.1 release

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,10 +27,12 @@ let package = Package(
         products: [
             .library(name: "Starscream", targets: ["Starscream"])
         ],
-        dependencies: [
-          .package(url: "https://github.com/apple/swift-nio-zlib-support.git", from: "1.0.0")
-        ],
+        dependencies: [],
         targets: [
             .target(name: "Starscream")
         ]
 )
+
+#if os(Linux)
+    package.dependencies.append(.package(url: "https://github.com/apple/swift-nio-zlib-support.git", from: "1.0.0"))
+#endif


### PR DESCRIPTION
### Goals ⚽
> What you hope to address within this PR.

Whilst fixed to v3.x of Starscream and using SPM a warning is still present. With settings such as treat warnings as errors checked this causes a few issues. 

### Implementation Details 🚧
> Additional details about the PR. 

Cherry pick #807 fix to the latest 3.1.1 release.