### PR TITLE
fix: crash as NWEndpoint requires a min target of 12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Check out [Get Started](http://cocoapods.org/) tab on [cocoapods.org](http://coc
 To use Starscream in your project add the following 'Podfile' to your project
 
 	source 'https://github.com/CocoaPods/Specs.git'
-	platform :ios, '11.0'
+	platform :ios, '12.0'
 	use_frameworks!
 
 	pod 'Starscream', '~> 4.0.6'

--- a/Starscream.podspec
+++ b/Starscream.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.author       = {'Dalton Cherry' => 'http://daltoniam.com', 'Austin Cherry' => 'http://austincherry.me'}
   s.source       = { :git => 'https://github.com/daltoniam/Starscream.git',  :tag => "#{s.version}"}
   s.social_media_url = 'http://twitter.com/daltoniam'
-  s.ios.deployment_target = '11.0'
+  s.ios.deployment_target = '12.0'
   s.osx.deployment_target = '10.13'
   s.tvos.deployment_target = '12.0'
   s.watchos.deployment_target = '2.0'


### PR DESCRIPTION
### Issue Link 🔗
#983

### Description
The use of https://developer.apple.com/documentation/network/nwendpoint requires a min target of iOS12.0
This results in crashes on phones using an iOS version lower than 17.

Fixes #983