### PR TITLE
Add privacy manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.3
 
 //
 //  Package.Swift
@@ -30,7 +30,8 @@ let package = Package(
         dependencies: [],
         targets: [
             .target(name: "Starscream",
-                    path: "Sources")
+                    path: "Sources",
+                    resources: [.copy("PrivacyInfo.xcprivacy")])
         ]
 )
 

--- a/Sources/PrivacyInfo.xcprivacy
+++ b/Sources/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSPrivacyTracking</key>
+    <false/>
+    <key>NSPrivacyTrackingDomains</key>
+    <array/>
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array/>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array/>
+</dict>
+</plist>

--- a/Starscream.podspec
+++ b/Starscream.podspec
@@ -13,4 +13,7 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = '2.0'
   s.source_files = 'Sources/**/*.swift'
   s.swift_version = '5.0'
+  s.resource_bundles = {
+    'Starscream_Privacy' => ['Sources/PrivacyInfo.xcprivacy'],
+  }
 end

--- a/Starscream.xcodeproj/project.pbxproj
+++ b/Starscream.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 53;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -36,6 +36,7 @@
 		8A906E3F2208C7E80015057D /* WSCompression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A906E3E2208C7E80015057D /* WSCompression.swift */; };
 		8ABD4470224C036A00FB8370 /* Data+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ABD446F224C036A00FB8370 /* Data+Extensions.swift */; };
 		BBB5ABE8215E2217005B48B6 /* WebSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB5ABE4215E2217005B48B6 /* WebSocket.swift */; };
+		FC7E667D2B90B3AD00881886 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = FC7E667C2B90B3AD00881886 /* PrivacyInfo.xcprivacy */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -80,6 +81,7 @@
 		BBB5ABE4215E2217005B48B6 /* WebSocket.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.swift; name = WebSocket.swift; path = Starscream/WebSocket.swift; sourceTree = "<group>"; tabWidth = 4; };
 		D88EAF811ED4DFD3004FE2C3 /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
 		D88EAF831ED4E7D8004FE2C3 /* CompressionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CompressionTests.swift; sourceTree = "<group>"; };
+		FC7E667C2B90B3AD00881886 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -160,6 +162,7 @@
 		6B3E79E919D48B7F006071F7 /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
+				FC7E667C2B90B3AD00881886 /* PrivacyInfo.xcprivacy */,
 				5C13600C1C473BFE00AA3A01 /* Info.plist */,
 			);
 			name = "Supporting Files";
@@ -336,6 +339,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FC7E667D2B90B3AD00881886 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
### Issue Link 🔗

A number of people are waiting for this feature [here](https://github.com/daltoniam/Starscream/issues/993).

### Goals ⚽

Adds the required privacy manifest to Starscream, along with support for Cocoapods & Swift PM.

### Implementation Details 🚧

From what I can tell, Starscream does not use any required reason APIs, nor does it collect any data. I have therefore added an "empty" privacy manifest which confirms this.

I have also added the necessary changes to the podspec (for Cocoapods) and Package.swift (for Swift PM) files. (This also required updated swift-tools-version to 5.3).

NOTE: One of the core maintainers should check that this privacy manifest is correct before merging, as I can take no personal responsibility for making this privacy manifest declaration! (It will also need to be kept up-to-date with any potential future changes to Starscream).