### PR TITLE
Avoid creating multiple URLSessions

### DIFF
--- a/Sources/Engine/NativeEngine.swift
+++ b/Sources/Engine/NativeEngine.swift
@@ -25,6 +25,7 @@ import Foundation
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public class NativeEngine: NSObject, Engine, URLSessionDataDelegate, URLSessionWebSocketDelegate {
     private var task: URLSessionWebSocketTask?
+    private var session: URLSession?
     weak var delegate: EngineDelegate?
 
     public func register(delegate: EngineDelegate) {
@@ -32,8 +33,10 @@ public class NativeEngine: NSObject, Engine, URLSessionDataDelegate, URLSessionW
     }
 
     public func start(request: URLRequest) {
-        let session = URLSession(configuration: URLSessionConfiguration.default, delegate: self, delegateQueue: nil)
-        task = session.webSocketTask(with: request)
+        if session == nil {
+            session = URLSession(configuration: URLSessionConfiguration.default, delegate: self, delegateQueue: nil)
+        }
+        task = session?.webSocketTask(with: request)
         doRead()
         task?.resume()
     }

--- a/Sources/Transport/FoundationTransport.swift
+++ b/Sources/Transport/FoundationTransport.swift
@@ -97,21 +97,21 @@ public class FoundationTransport: NSObject, Transport, StreamDelegate {
     public func disconnect() {
         // Capture strong references before niling the instance vars.
         // CFReadStreamSetDispatchQueue(stream, nil) stops future event blocks from being
-        // enqueued, but blocks already in the queue hold a raw C pointer to the CFStream
-        // and will still execute. If the streams are deallocated before those blocks run,
-        // CFRetain/CFRelease inside _signalEventSync crashes with a pointer-authentication
-        // trap (EXC_BREAKPOINT SIGTRAP). Holding the streams alive in a trailing async
-        // block on the same serial queue guarantees they outlive all preceding callbacks.
+        // enqueued, but blocks already in the queue hold a raw C pointer to the CFStream's
+        // internal __NSCFStreamWeakDelegateWrapper. Setting stream.delegate = nil frees
+        // that wrapper immediately; the queued blocks then crash with objc_retain on the
+        // freed wrapper inside _signalEventSync (EXC_BREAKPOINT SIGTRAP / EXC_BAD_ACCESS).
+        // Fix: defer delegate = nil to the trailing workQueue block, which executes only
+        // after all previously-enqueued CFStream callbacks have already run. The streams
+        // themselves are kept alive by the same block via ARC captures.
         let capturedInput = inputStream
         let capturedOutput = outputStream
 
         if let stream = capturedInput {
-            stream.delegate = nil
             CFReadStreamSetDispatchQueue(stream, nil)
             stream.close()
         }
         if let stream = capturedOutput {
-            stream.delegate = nil
             CFWriteStreamSetDispatchQueue(stream, nil)
             stream.close()
         }
@@ -119,7 +119,11 @@ public class FoundationTransport: NSObject, Transport, StreamDelegate {
         outputStream = nil
         inputStream = nil
 
-        workQueue.async { _ = (capturedInput, capturedOutput) }
+        workQueue.async {
+            capturedInput?.delegate = nil
+            capturedOutput?.delegate = nil
+            _ = (capturedInput, capturedOutput)
+        }
     }
     
     public func register(delegate: TransportEventClient) {

--- a/Sources/Transport/FoundationTransport.swift
+++ b/Sources/Transport/FoundationTransport.swift
@@ -95,12 +95,22 @@ public class FoundationTransport: NSObject, Transport, StreamDelegate {
     }
     
     public func disconnect() {
-        if let stream = inputStream {
+        // Capture strong references before niling the instance vars.
+        // CFReadStreamSetDispatchQueue(stream, nil) stops future event blocks from being
+        // enqueued, but blocks already in the queue hold a raw C pointer to the CFStream
+        // and will still execute. If the streams are deallocated before those blocks run,
+        // CFRetain/CFRelease inside _signalEventSync crashes with a pointer-authentication
+        // trap (EXC_BREAKPOINT SIGTRAP). Holding the streams alive in a trailing async
+        // block on the same serial queue guarantees they outlive all preceding callbacks.
+        let capturedInput = inputStream
+        let capturedOutput = outputStream
+
+        if let stream = capturedInput {
             stream.delegate = nil
             CFReadStreamSetDispatchQueue(stream, nil)
             stream.close()
         }
-        if let stream = outputStream {
+        if let stream = capturedOutput {
             stream.delegate = nil
             CFWriteStreamSetDispatchQueue(stream, nil)
             stream.close()
@@ -108,6 +118,8 @@ public class FoundationTransport: NSObject, Transport, StreamDelegate {
         isOpen = false
         outputStream = nil
         inputStream = nil
+
+        workQueue.async { _ = (capturedInput, capturedOutput) }
     }
     
     public func register(delegate: TransportEventClient) {


### PR DESCRIPTION
### Issue Link 🔗
> Please attach the link to an issue if it exists.

### Goals ⚽
> What you hope to address within this PR.

Apple guidelines recommend that we don't create several URLSession, also, some users may face `POSIXErrorCode(rawValue: 28): No space left on device` when a certain number of URLSessions were already created. I don't know all edge cases that this lib handles, so this is just an initial suggestion

Related: https://stackoverflow.com/questions/67318867/error-domain-nsposixerrordomain-code-28-no-space-left-on-device-userinfo-kcf


### Implementation Details 🚧
> Additional details about the PR. 
