### PR TITLE
Propagate errors triggered on 'waiting'

### DIFF
--- a/Sources/Engine/WSEngine.swift
+++ b/Sources/Engine/WSEngine.swift
@@ -143,8 +143,8 @@ FrameCollectorDelegate, HTTPHandlerDelegate {
             let wsReq = HTTPWSHeader.createUpgrade(request: request, supportsCompression: framer.supportsCompression(), secKeyValue: secKeyValue)
             let data = httpHandler.convert(request: wsReq)
             transport.write(data: data, completion: {_ in })
-        case .waiting:
-            break
+        case .waiting(let error):
+            broadcast(event: .waiting(error))
         case .failed(let error):
             handleError(error)
         case .viability(let isViable):

--- a/Sources/Starscream/WebSocket.swift
+++ b/Sources/Starscream/WebSocket.swift
@@ -82,6 +82,7 @@ public enum WebSocketEvent {
     case pong(Data?)
     case ping(Data?)
     case error(Error?)
+    case waiting(Error)
     case viabilityChanged(Bool)
     case reconnectSuggested(Bool)
     case cancelled

--- a/Sources/Transport/TCPTransport.swift
+++ b/Sources/Transport/TCPTransport.swift
@@ -110,8 +110,8 @@ public class TCPTransport: Transport {
             switch newState {
             case .ready:
                 self?.delegate?.connectionChanged(state: .connected)
-            case .waiting:
-                self?.delegate?.connectionChanged(state: .waiting)
+            case .waiting(let error):
+                self?.delegate?.connectionChanged(state: .waiting(error))
             case .cancelled:
                 self?.delegate?.connectionChanged(state: .cancelled)
             case .failed(let error):

--- a/Sources/Transport/Transport.swift
+++ b/Sources/Transport/Transport.swift
@@ -27,7 +27,7 @@ public enum ConnectionState {
     case connected
     
     /// Waiting connections have not yet been started, or do not have a viable network
-    case waiting
+    case waiting(Error)
     
     /// Cancelled connections have been invalidated by the client and will send no more events
     case cancelled


### PR DESCRIPTION
### Goals ⚽
When Starscream uses the `NWConnection` from the Network framework (iOS 12+), some scenarios just fail silently without any type of feedback or callback back to the caller. 

This is mainly due the fact that those errors are being returned when the connection state is `waiting`. According to Apple's documentation

> Connections that are waiting will indicate the reason that the connection couldn't be established in the associated error. These errors are not fatal.

But this state is being reached on 'fatal errors' like connection rejected because SSL pinning failed or timeouts. In those cases, as the `waiting` state is reached, Starscream just ignores the returned error and the client will just wait as it won't receive any callback.

### Implementation Details 🚧

To maintain compatibility with older implementations and to not modify existing behaviour a new `WebSocketEvent` has been added `waiting(Error)`. This will contain the error propagated from the `TCPTransport`

