### PR TITLE
Resolve memory leak on NativeEngine

### DIFF
--- a/Sources/Engine/NativeEngine.swift
+++ b/Sources/Engine/NativeEngine.swift
@@ -25,6 +25,7 @@ import Foundation
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public class NativeEngine: NSObject, Engine, URLSessionDataDelegate, URLSessionWebSocketDelegate {
     private var task: URLSessionWebSocketTask?
+    private var session: URLSession?
     weak var delegate: EngineDelegate?
 
     public func register(delegate: EngineDelegate) {
@@ -32,10 +33,14 @@ public class NativeEngine: NSObject, Engine, URLSessionDataDelegate, URLSessionW
     }
 
     public func start(request: URLRequest) {
-        let session = URLSession(configuration: URLSessionConfiguration.default, delegate: self, delegateQueue: nil)
-        task = session.webSocketTask(with: request)
+        session = URLSession(configuration: URLSessionConfiguration.default, delegate: self, delegateQueue: nil)
+        task = session?.webSocketTask(with: request)
         doRead()
         task?.resume()
+    }
+
+    public func closeSession() {
+        session?.finishTasksAndInvalidate()
     }
 
     public func stop(closeCode: UInt16) {

--- a/Sources/Starscream/WebSocket.swift
+++ b/Sources/Starscream/WebSocket.swift
@@ -125,7 +125,15 @@ open class WebSocket: WebSocketClient, EngineDelegate {
             self.init(request: request, engine: WSEngine(transport: FoundationTransport(), certPinner: certPinner, compressionHandler: compressionHandler))
         }
     }
-    
+
+    deinit {
+        if #available(iOS 13.0, *) {
+            if let engine = engine as? NativeEngine {
+                engine.closeSession()
+            }
+        }
+    }
+
     public func connect() {
         engine.register(delegate: self)
         engine.start(request: request)


### PR DESCRIPTION
### Issue Link 🔗
Fixes #832 (Is there a way to 'clean up' socket connection to avoid memory leaks, before attempting to reconnect?)
Fixes #938 (Memory leak when use native engine)
Fixes #995 (if you socket resart many time,cpu is very busy and Forever and ever)

### Goals ⚽
According to the [Apple document](https://developer.apple.com/documentation/foundation/urlsession/1411597-init), 
> The session object keeps a strong reference to the delegate until your app exits or explicitly invalidates the session. If you do not invalidate the session by calling the [invalidateAndCancel()](https://developer.apple.com/documentation/foundation/urlsession/1411538-invalidateandcancel) or [finishTasksAndInvalidate()](https://developer.apple.com/documentation/foundation/urlsession/1407428-finishtasksandinvalidate) method, your app leaks memory until it exits.

The URLSession is retained because neither invalidateAndCancel() nor finishTasksAndInvalidate() has been called. Consequently, this leads to memory leaks after initializing a new WebSocket and establishing a connection.

### Implementation Details 🚧
Invalidate the NativeEngine's URLSession at WebSocket dealloc.

Unit Test Results: Passed
![Screenshot 2024-10-20 at 5 28 56 PM](https://github.com/user-attachments/assets/855223f1-c054-48b3-9cd7-3a777a430a64)

