### PR TITLE
Revert "Fix connection race when using WSEngine"

### DIFF
--- a/Sources/Engine/WSEngine.swift
+++ b/Sources/Engine/WSEngine.swift
@@ -38,7 +38,6 @@ FrameCollectorDelegate, HTTPHandlerDelegate {
     private let writeQueue = DispatchQueue(label: "com.vluxe.starscream.writequeue")
     private let mutex = DispatchSemaphore(value: 1)
     private var canSend = false
-    private var isConnecting = false
     
     weak var delegate: EngineDelegate?
     public var respondToPingWithPong: Bool = true
@@ -65,10 +64,9 @@ FrameCollectorDelegate, HTTPHandlerDelegate {
     
     public func start(request: URLRequest) {
         mutex.wait()
-        let isConnecting = self.isConnecting
         let isConnected = canSend
         mutex.signal()
-        if isConnecting || isConnected {
+        if isConnected {
             return
         }
         
@@ -80,9 +78,6 @@ FrameCollectorDelegate, HTTPHandlerDelegate {
         guard let url = request.url else {
             return
         }
-        mutex.wait()
-        self.isConnecting = true
-        mutex.signal()
         transport.connect(url: url, timeout: request.timeoutInterval, certificatePinning: certPinner)
     }
     
@@ -98,10 +93,6 @@ FrameCollectorDelegate, HTTPHandlerDelegate {
     }
     
     public func forceStop() {
-        mutex.wait()
-        isConnecting = false
-        mutex.signal()
-        
         transport.disconnect()
     }
     
@@ -162,10 +153,6 @@ FrameCollectorDelegate, HTTPHandlerDelegate {
                 }
             }
         case .cancelled:
-            mutex.wait()
-            isConnecting = false
-            mutex.signal()
-            
             broadcast(event: .cancelled)
         case .peerClosed:
             broadcast(event: .peerClosed)
@@ -182,7 +169,6 @@ FrameCollectorDelegate, HTTPHandlerDelegate {
                 return
             }
             mutex.wait()
-            isConnecting = false
             didUpgrade = true
             canSend = true
             mutex.signal()
@@ -255,7 +241,6 @@ FrameCollectorDelegate, HTTPHandlerDelegate {
     
     private func reset() {
         mutex.wait()
-        isConnecting = false
         canSend = false
         didUpgrade = false
         mutex.signal()


### PR DESCRIPTION
Reverts daltoniam/Starscream#930

We've also identified [an issue with handling the "isConnecting" flag](https://github.com/daltoniam/Starscream/pull/930#issuecomment-2149276411). Once triggered, it doesn't automatically reconnect. For now, I believe we should revert this change.