### PR TITLE
Fix: connect() Does Not Proceed When Peer is Closed 🛠️

### DIFF
--- a/Sources/Engine/WSEngine.swift
+++ b/Sources/Engine/WSEngine.swift
@@ -168,6 +168,10 @@ FrameCollectorDelegate, HTTPHandlerDelegate {
             
             broadcast(event: .cancelled)
         case .peerClosed:
+            mutex.wait()
+            isConnecting = false
+            mutex.signal()
+
             broadcast(event: .peerClosed)
         }
     }

--- a/Sources/Engine/WSEngine.swift
+++ b/Sources/Engine/WSEngine.swift
@@ -143,8 +143,12 @@ FrameCollectorDelegate, HTTPHandlerDelegate {
             let wsReq = HTTPWSHeader.createUpgrade(request: request, supportsCompression: framer.supportsCompression(), secKeyValue: secKeyValue)
             let data = httpHandler.convert(request: wsReq)
             transport.write(data: data, completion: {_ in })
-        case .waiting:
-            break
+        case .waiting(let error):
+            mutex.wait()
+            isConnecting = false
+            mutex.signal()
+
+            broadcast(event: .waiting(error))
         case .failed(let error):
             handleError(error)
         case .viability(let isViable):

--- a/Sources/Starscream/WebSocket.swift
+++ b/Sources/Starscream/WebSocket.swift
@@ -86,6 +86,7 @@ public enum WebSocketEvent {
     case reconnectSuggested(Bool)
     case cancelled
     case peerClosed
+    case waiting(Error?)
 }
 
 public protocol WebSocketDelegate: AnyObject {

--- a/Sources/Transport/TCPTransport.swift
+++ b/Sources/Transport/TCPTransport.swift
@@ -110,8 +110,8 @@ public class TCPTransport: Transport {
             switch newState {
             case .ready:
                 self?.delegate?.connectionChanged(state: .connected)
-            case .waiting:
-                self?.delegate?.connectionChanged(state: .waiting)
+            case .waiting(let error):
+                self?.delegate?.connectionChanged(state: .waiting(error))
             case .cancelled:
                 self?.delegate?.connectionChanged(state: .cancelled)
             case .failed(let error):

--- a/Sources/Transport/Transport.swift
+++ b/Sources/Transport/Transport.swift
@@ -27,7 +27,7 @@ public enum ConnectionState {
     case connected
     
     /// Waiting connections have not yet been started, or do not have a viable network
-    case waiting
+    case waiting(Error?)
     
     /// Cancelled connections have been invalidated by the client and will send no more events
     case cancelled


### PR DESCRIPTION
### Issue Link 🔗
Fixes #1052

### Goals ⚽
This PR aims to fix a bug where `isConnecting` remains true indefinitely, preventing `connect()` from proceeding after a WebSocket peer closes.

As discussed in [#1052](https://github.com/daltoniam/Starscream/issues/1052), this occurs when:

1. The device enters sleep mode (causing WebSocket closure).
2. The server goes down during sleep.
3. The app tries to reconnect, but isConnecting remains true, blocking new connections forever.

📝 There are alternative steps to reproduce the issue, but this is the simplest method.  
In other words, **step 2** can be replaced by an extended sleep duration.

Additionally, this PR now includes a fix for [another related scenario](https://github.com/daltoniam/Starscream/issues/1052#issuecomment-2696923634) where `isConnecting` remains stuck when the WebSocket receives a `waiting` error.

### Implementation Details 🚧

**Fix for `.peerClosed` Issue**

- Ensures that isConnecting is properly reset to false when the WebSocket receives a `.peerClosed` event (introduced in [#946](https://github.com/daltoniam/Starscream/pull/946)).

**Fix for `.waiting(Error?)` Issue**

- The `waiting` state now includes an optional error (`case waiting(Error?)`).
- `isConnecting` is now reset to false when a `waiting` error is received.
- This prevents the connection from getting stuck in an unusable state.

### Testing ✅

- Reproduced both the peerClosed and waiting error issues using the [SampleStarscream](https://github.com/yoheimuta/SampleStarscream) project.
- Verified that `connect()` now proceeds correctly after `.peerClosed` and `.waiting(error)`, allowing successful reconnections.
- Checked logs with `NSLog` to confirm that `isConnecting` resets properly.